### PR TITLE
feat: login diretto SISTER per intestatari della convenzione (uso personale)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Entrambe le richieste vengono accodate ed eseguite sequenzialmente su un singolo
 
 ### Funzionalità principali
 
-- **Autenticazione SPID automatizzata** via provider Sielte ID (CIE Sign) con push notification
+- **Autenticazione SPID/SISTER automatizzata** — provider Sielte ID, PosteID o login diretto SISTER (selezionabile via `SPID_PROVIDER`)
 - **Coda sequenziale** — le richieste vengono processate una alla volta per non sovraccaricare il portale
 - **Ri-autenticazione automatica** — alla scadenza della sessione, il servizio tenta prima un recovery diretto e, solo se necessario, un nuovo login SPID
 - **Keep-alive** — la sessione viene mantenuta attiva con un light keep-alive ogni 30 secondi e un refresh profondo ogni 5 minuti
@@ -62,9 +62,23 @@ Entrambe le richieste vengono accodate ed eseguite sequenzialmente su un singolo
 - **Logging HTML completo** — ogni pagina visitata dal browser viene salvata su disco per debug e audit
 - **Docker-ready** — immagine pronta con tutte le dipendenze di sistema per Chromium headless
 
-### Compatibilità SPID
+### Provider di autenticazione supportati
 
-Il login automatizzato funziona **esclusivamente** con il provider **Sielte ID (CIE Sign)**. Il flusso prevede l'approvazione via push notification sull'app MySielteID. Altri provider SPID non sono supportati e richiederebbero modifiche alla funzione `login()` in `utils.py`.
+Il provider è selezionato dalla variabile d'ambiente `SPID_PROVIDER` (case-insensitive, default `sielte`):
+
+| `SPID_PROVIDER` | Provider | Credenziali richieste | 2° fattore |
+|-----------------|----------|------------------------|------------|
+| `sielte` (default) | SPID Sielte ID | `ADE_USERNAME`, `ADE_PASSWORD` | push notification su app MySielteID |
+| `poste` | SPID PosteID | `POSTE_USERNAME`, `POSTE_PASSWORD` | approvazione su app PosteID |
+| `sister` | Login diretto SISTER (tab dedicato sulla pagina ADE) | `SISTER_USERNAME`, `SISTER_PASSWORD` | nessuno (credenziali nominali professionali) |
+
+#### Scope d'uso ammesso per il provider `sister`
+
+> Il login diretto SISTER è destinato esclusivamente all'**intestatario della convenzione SISTER** che desidera automatizzare le proprie consultazioni con le proprie credenziali nominali.
+>
+> **Non è destinato** a chi vuole rivendere o esporre l'accesso al portale SISTER a terzi: la convenzione SISTER (Agenzia delle Entrate) richiede che l'utenza sia personale, non cedibile, e che le consultazioni siano riconducibili all'intestatario.
+>
+> Questo progetto è una libreria di automazione: la responsabilità dell'uso delle credenziali e del rispetto dei termini di convenzione resta dell'intestatario, esattamente come per il flusso SPID.
 
 ### Limitazioni note
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -166,6 +166,34 @@ def test_login_provider_value_is_case_insensitive(monkeypatch):
         asyncio.run(utils.login(object()))
 
 
+def test_login_sister_provider_requires_sister_credentials(monkeypatch):
+    """SPID_PROVIDER='sister' senza SISTER_USERNAME/PASSWORD → ValueError."""
+    monkeypatch.setenv("SPID_PROVIDER", "sister")
+    monkeypatch.delenv("SISTER_USERNAME", raising=False)
+    monkeypatch.delenv("SISTER_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="SISTER_USERNAME"):
+        asyncio.run(utils.login(object()))
+
+
+def test_login_sister_provider_case_insensitive(monkeypatch):
+    """SPID_PROVIDER='SISTER' (maiuscolo) deve essere normalizzato a 'sister'."""
+    monkeypatch.setenv("SPID_PROVIDER", "SISTER")
+    monkeypatch.delenv("SISTER_USERNAME", raising=False)
+    monkeypatch.delenv("SISTER_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="SISTER_USERNAME"):
+        asyncio.run(utils.login(object()))
+
+
+def test_login_unknown_provider_error_lists_sister(monkeypatch):
+    """Il messaggio di errore deve includere 'sister' tra i valori validi."""
+    monkeypatch.setenv("SPID_PROVIDER", "lepida")
+
+    with pytest.raises(ValueError, match="sister"):
+        asyncio.run(utils.login(object()))
+
+
 def test_run_visura_immobile_requires_subalterno(monkeypatch, tmp_path):
     monkeypatch.setattr(utils, "PAGES_LOG_DIR", str(tmp_path))
 

--- a/utils.py
+++ b/utils.py
@@ -308,8 +308,7 @@ async def login(page: Page):
             raise ValueError("SISTER_USERNAME and SISTER_PASSWORD environment variables must be set")
     else:
         raise ValueError(
-            f"SPID_PROVIDER non supportato: '{spid_provider}'. "
-            "Valori validi: 'sielte', 'poste', 'sister'"
+            f"SPID_PROVIDER non supportato: '{spid_provider}'. " "Valori validi: 'sielte', 'poste', 'sister'"
         )
 
     logger = PageLogger("login")
@@ -433,12 +432,41 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
         await page.wait_for_load_state("networkidle", timeout=30000)
         await logger.log(page, "portale_sister")
 
-        # Verifica blocco sessione (stessa logica del flusso SPID)
-        content = await page.content()
-        url = page.url
-        if "Utente gia' in sessione" in content or "error_locked.jsp" in url:
-            print("[LOGIN][ERRORE] Utente già in sessione su un'altra postazione!")
-            raise Exception("Utente già in sessione su un'altra postazione")
+        # Gestione sessioni orfane: ogni CloseSessionsSis chiude UNA sessione
+        # stale. Dopo molti riavvii possono accumularsi più sessioni, perciò
+        # proviamo fino a 10 volte prima di alzare l'eccezione.
+        for attempt in range(1, 11):
+            content = await page.content()
+            url = page.url
+            if "Utente gia' in sessione" not in content and "error_locked.jsp" not in url:
+                break
+
+            print(f"[LOGIN] Sessione orfana rilevata (tentativo {attempt}/10) — chiudo e riprovo...")
+            step = f"close_session_{attempt}"
+            await page.goto(
+                "https://sister3.agenziaentrate.gov.it/Servizi/CloseSessionsSis",
+                timeout=30000,
+            )
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
+            await logger.log(page, f"close_session_{attempt}")
+
+            step = f"sister_tab_retry_{attempt}"
+            await page.goto(
+                "https://iampe.agenziaentrate.gov.it/sam/UI/Login?realm=/agenziaentrate",
+                timeout=30000,
+            )
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
+            await page.get_by_role("tab", name="Sister").click()
+            await page.get_by_role("textbox", name="Utente:").fill(username)
+            await page.get_by_role("textbox", name="Password:").fill(password)
+            await page.get_by_role("button", name="Accedi").click()
+            await page.wait_for_load_state("networkidle", timeout=30000)
+            await logger.log(page, f"portale_sister_retry_{attempt}")
+        else:
+            print("[LOGIN][ERRORE] Troppe sessioni orfane, impossibile liberare la sessione.")
+            raise Exception("Utente già in sessione su un'altra postazione (max 10 tentativi raggiunto)")
+
+        print("[LOGIN] Login SISTER completato.")
 
     except Exception:
         await logger.log(page, f"ERRORE_sister_{step}")

--- a/utils.py
+++ b/utils.py
@@ -271,13 +271,23 @@ async def _login_poste(page: Page, logger: PageLogger, username: str, password: 
 async def login(page: Page):
     """Esegue il login completo (SPID + navigazione fino a 'Visure catastali').
 
-    Il provider SPID è selezionato dalla variabile d'ambiente ``SPID_PROVIDER``:
+    Il provider di autenticazione è selezionato dalla variabile d'ambiente
+    ``SPID_PROVIDER`` (case-insensitive):
 
-    * ``sielte`` (default) — Sielte ID, credenziali ``ADE_USERNAME`` / ``ADE_PASSWORD``
-    * ``poste`` — PosteID, credenziali ``POSTE_USERNAME`` / ``POSTE_PASSWORD``
+    * ``sielte`` (default) — SPID Sielte ID, credenziali ``ADE_USERNAME`` /
+      ``ADE_PASSWORD``.
+    * ``poste`` — SPID PosteID, credenziali ``POSTE_USERNAME`` /
+      ``POSTE_PASSWORD``.
+    * ``sister`` — login diretto SISTER tramite il tab dedicato della pagina
+      ADE, credenziali ``SISTER_USERNAME`` / ``SISTER_PASSWORD``. Pensato per
+      l'**intestatario** di una convenzione SISTER che vuole automatizzare le
+      proprie consultazioni con le proprie credenziali nominali (vedi README,
+      sezione "Provider di autenticazione supportati").
 
-    Dopo l'autenticazione SPID il flusso prosegue identico: ricerca del servizio
+    Con i provider SPID il flusso prosegue identico: ricerca del servizio
     SISTER, conferma, navigazione fino a "Visure catastali → Conferma Lettura".
+    Con il provider ``sister`` il login diretto atterra già nell'area del
+    servizio e quei passi vengono saltati.
     """
     spid_provider = os.getenv("SPID_PROVIDER", "sielte").lower()
 
@@ -291,8 +301,16 @@ async def login(page: Page):
         password = os.getenv("POSTE_PASSWORD")
         if not username or not password:
             raise ValueError("POSTE_USERNAME and POSTE_PASSWORD environment variables must be set")
+    elif spid_provider == "sister":
+        username = os.getenv("SISTER_USERNAME")
+        password = os.getenv("SISTER_PASSWORD")
+        if not username or not password:
+            raise ValueError("SISTER_USERNAME and SISTER_PASSWORD environment variables must be set")
     else:
-        raise ValueError(f"SPID_PROVIDER non supportato: '{spid_provider}'. Valori validi: 'sielte', 'poste'")
+        raise ValueError(
+            f"SPID_PROVIDER non supportato: '{spid_provider}'. "
+            "Valori validi: 'sielte', 'poste', 'sister'"
+        )
 
     logger = PageLogger("login")
     step = "init"
@@ -302,6 +320,15 @@ async def login(page: Page):
         print("[LOGIN] Navigo alla pagina di login...")
         await page.goto("https://iampe.agenziaentrate.gov.it/sam/UI/Login?realm=/agenziaentrate")
         await logger.log(page, "goto_login")
+
+        if spid_provider == "sister":
+            # Login diretto SISTER: bypass completo della navigazione ADE portal
+            # (cerca SISTER → Vai al servizio → Conferma → Consultazioni →
+            # Visure catastali → Conferma Lettura) perché l'area servizio si
+            # apre già dopo l'autenticazione SISTER nominale.
+            step = "provider_sister"
+            await _login_sister_direct(page, logger, username, password)
+            return
 
         step = "entra_con_spid"
         print("[LOGIN] Clicco 'Entra con SPID'...")
@@ -359,6 +386,62 @@ async def login(page: Page):
 
     except Exception:
         await logger.log(page, f"ERRORE_{step}")
+        raise
+
+
+async def _login_sister_direct(page: Page, logger: PageLogger, username: str, password: str) -> None:
+    """Esegue il login diretto SISTER tramite il tab dedicato sulla pagina ADE.
+
+    Credenziali richieste:
+        SISTER_USERNAME — username dell'account SISTER nominale dell'utente
+        SISTER_PASSWORD — password dell'account SISTER nominale dell'utente
+
+    Scope d'uso ammesso: questo flusso è destinato all'**intestatario della
+    convenzione SISTER** che desidera automatizzare le proprie consultazioni
+    con le proprie credenziali nominali. Non è destinato a chi vuole rivendere
+    o esporre l'accesso al portale SISTER a terzi (la convenzione SISTER
+    richiede che l'utenza sia personale, non cedibile, e che le consultazioni
+    siano riconducibili all'intestatario).
+
+    Dopo il login si atterra direttamente nella pagina SceltaServizio di
+    SISTER, saltando la navigazione tramite portale ADE (Cerca servizio →
+    Vai al servizio → Conferma → Consultazioni → Visure catastali → Conferma
+    Lettura) che non è necessaria con il login diretto.
+    """
+    step = "sister_tab"
+    try:
+        print("[LOGIN] Clicco tab 'Sister'...")
+        await page.get_by_role("tab", name="Sister").click()
+        await logger.log(page, "sister_tab")
+
+        step = "username"
+        print("[LOGIN] Inserisco username SISTER...")
+        await page.get_by_role("textbox", name="Utente:").fill(username)
+        await logger.log(page, "username")
+
+        step = "password"
+        print("[LOGIN] Inserisco password SISTER...")
+        await page.get_by_role("textbox", name="Password:").fill(password)
+
+        step = "accedi"
+        print("[LOGIN] Clicco 'Accedi'...")
+        await page.get_by_role("button", name="Accedi").click()
+        await logger.log(page, "accedi")
+
+        step = "attesa_sister"
+        print("[LOGIN] Attendo caricamento portale SISTER...")
+        await page.wait_for_load_state("networkidle", timeout=30000)
+        await logger.log(page, "portale_sister")
+
+        # Verifica blocco sessione (stessa logica del flusso SPID)
+        content = await page.content()
+        url = page.url
+        if "Utente gia' in sessione" in content or "error_locked.jsp" in url:
+            print("[LOGIN][ERRORE] Utente già in sessione su un'altra postazione!")
+            raise Exception("Utente già in sessione su un'altra postazione")
+
+    except Exception:
+        await logger.log(page, f"ERRORE_sister_{step}")
         raise
 
 


### PR DESCRIPTION
Risolve #35.

## Cosa cambia

Aggiunge il provider `SPID_PROVIDER=sister` al dispatcher introdotto in #31 (provider Poste): login diretto al portale SISTER tramite il tab dedicato sulla pagina ADE, con credenziali nominali della convenzione.

### Riepilogo tecnico

- `utils._login_sister_direct(page, logger, username, password)` — clicca il tab "Sister", inserisce `SISTER_USERNAME`/`SISTER_PASSWORD`, clicca "Accedi", attende `networkidle`.
- `utils.login()` — branching dopo `goto_login`: se `SPID_PROVIDER=sister` chiama direttamente `_login_sister_direct()` e ritorna, bypassando "Entra con SPID" e l'intera navigazione ADE portal (cerca SISTER → Vai al servizio → Conferma → Consultazioni → Visure catastali → Conferma Lettura), non necessaria perché il login SISTER nominale atterra già nell'area servizio.
- **Gestione sessioni orfane**: fino a 10 tentativi di `CloseSessionsSis` + ri-login automatici prima di alzare l'eccezione (il sistema SISTER blocca quando rileva una sessione precedente non chiusa correttamente).
- Test: 3 nuovi test per il dispatcher SISTER (credenziali mancanti, case-insensitive, messaggio errore valori validi).

### Scope d'uso esplicito (anche in README e docstring)

> Il login diretto SISTER è destinato esclusivamente all'**intestatario della convenzione SISTER** che desidera automatizzare le proprie consultazioni con le proprie credenziali nominali. Non è destinato a chi vuole rivendere o esporre l'accesso a terzi: la convenzione SISTER richiede che l'utenza sia personale, non cedibile, e che le consultazioni siano riconducibili all'intestatario. La responsabilità dell'uso delle credenziali resta dell'intestatario, esattamente come per il flusso SPID.

Documentazione aggiunta in `README.md`, sezione **Provider di autenticazione supportati**, e nella docstring di `_login_sister_direct`.

## Dipendenza

Questa PR si basa su `feat/spid-provider-poste` (#31): se #31 viene mergiato prima, GitHub rebaserà automaticamente questa PR su `main`. Se viene mergiato dopo, il rebase è banale (estende lo stesso dispatcher).

## Provenienza upstream

Cherry-pick di:
- [`pietromalerba/visura-api@6bcd072`](https://github.com/pietromalerba/visura-api/commit/6bcd07202bc0bf61b51aea163bd235868571f2a2) — estrazione `_login_sister_direct` + dispatcher
- [`pietromalerba/visura-api@b2d606d`](https://github.com/pietromalerba/visura-api/commit/b2d606dc37a3a2fa7a8ccf7da693e71d6360d41a) — retry `CloseSessionsSis` fino a 10 tentativi

Adattamenti rispetto all'upstream:
- merge con il dispatcher SPID Poste introdotto in #31 (l'upstream conosce solo `sielte`+`sister`; qui supportiamo `sielte`+`poste`+`sister`)
- ampliamento docstring con scope d'uso ammesso
- aggiunta sezione README dedicata
- test estesi per coprire anche il provider `sister`

## Compatibilità

Retrocompatibile: default invariato `SPID_PROVIDER=sielte`. Nessun cambiamento per chi usa SPID Sielte o Poste.

## Test

```
PYTHONPATH=. ADE_USERNAME=test ADE_PASSWORD=test pytest tests/ -q
49 passed
```

Lint:
```
black --check .  → All done
ruff check .     → All checks passed
```

## Check di review

- [x] DCO sign-off su tutti i commit
- [x] `(cherry picked from commit ...)` su entrambi i pick (`-x`)
- [x] Co-author = Pietro Malerba (preservato dal cherry-pick)
- [x] CI verde locale (black + ruff + 49 test)
- [x] Issue collegata (#35) con framing esplicito
- [x] README aggiornato con scope d'uso
