### PR TITLE
feat(visura-api): robustezza, performance e retry login pre-produzione

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,20 @@ LOGIN_AUTORIZZA_APPEAR_TIMEOUT_S=15
 # Idem per PosteID: tempo massimo per uscire dal form di login dopo 'Avanti'.
 LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S=15
 
+# === Login retry su push SPID non approvata ===
+
+# Numero massimo di tentativi di login se la push SPID non viene approvata
+# in tempo dall'utente (timeout 120s sul click 'Autorizza' Sielte o sul
+# redirect post-push Poste). Ogni tentativo invia una nuova notifica push.
+# I tentativi NON si applicano agli errori di credenziali errate (fail-fast).
+# Default 3.
+LOGIN_MAX_ATTEMPTS=3
+
+# Secondi di attesa tra un tentativo di login fallito e il successivo
+# (per evitare push back-to-back e dare tempo all'utente di prepararsi).
+# Default 5.
+LOGIN_RETRY_DELAY_S=5
+
 # Directory dove salvare gli HTML delle pagine visitate dal browser per debug.
 # Se non scrivibile, il servizio prova /tmp/visura-api/logs/pages come fallback;
 # se anche quella non è scrivibile, il logging delle pagine viene disabilitato

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,30 @@ LOG_LEVEL=INFO
 # Numero di worker concorrenti
 CONCURRENT_WORKERS=3
 
+# === Rate limit & cache ===
+
+# Backlog massimo della coda visure: richieste in eccesso → HTTP 429
+# (default 200, default storico era illimitato).
+MAX_QUEUE_SIZE=200
+
+# TTL in secondi dei risultati visura nello store in memoria (default 3600 = 1h).
+# Oltre questo tempo il client deve rifare la visura: fix memory leak F5.
+RESPONSE_TTL_SECONDS=3600
+
+# Cap massimo entry simultanee nello store (LRU eviction oltre soglia).
+RESPONSE_STORE_MAXSIZE=10000
+
+# === Login fail-fast (P1 #8) ===
+
+# Tempo massimo (s) di attesa per il pulsante 'Autorizza' su Sielte dopo
+# l'invio di username/password. Se non appare entro questo timeout il login
+# fallisce con errore esplicito (= credenziali probabilmente errate) invece
+# di restare appeso 120s sulla notifica push. Default 15.
+LOGIN_AUTORIZZA_APPEAR_TIMEOUT_S=15
+
+# Idem per PosteID: tempo massimo per uscire dal form di login dopo 'Avanti'.
+LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S=15
+
 # Directory dove salvare gli HTML delle pagine visitate dal browser per debug.
 # Se non scrivibile, il servizio prova /tmp/visura-api/logs/pages come fallback;
 # se anche quella non è scrivibile, il logging delle pagine viene disabilitato

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,29 @@ LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S=15
 # riduce ~0.5-2s di latenza per ogni richiesta visura.
 LOG_PAGES=0
 
+# === Perf MVP-2: resource blocking + dropdown cache (2026-05-15) ===
+
+# Resource blocking via Playwright route handler. Default attivo ("1").
+# Quando attivo blocca i tipi elencati in RESOURCE_BLOCK_TYPES (default
+# "image,font,media") riducendo ~1-2s/richiesta di asset SISTER inutili.
+# Imposta "0" per disabilitare interamente (debugging: utile quando si
+# sospetta che il blocking causi failure su un selector inatteso).
+# Diagnostica: ogni blocco e' contato in BrowserManager.blocked_resources_count
+# e i primi 10 URL sono loggati con tag [BLOCK] per ispezione.
+RESOURCE_BLOCK=1
+# RESOURCE_BLOCK_TYPES=image,font,media
+# stylesheet NON e' bloccato di default per evitare di rompere le check di
+# visibility Playwright basate su CSS computed. Aggiungere "stylesheet" alla
+# lista per spingere ulteriormente la perf, dopo aver validato live.
+
+# Cache process-wide delle dropdown SISTER (province + comuni-per-provincia).
+# Default attivo ("1"). Sostituisce ~600-1800ms di IPC CDP per request con
+# un singolo lookup O(1) sui dict in memoria. Imposta "0" per disabilitare
+# (debugging: forza re-fetch via page.evaluate ad ogni request).
+# Diagnostica: ogni accesso emette [CACHE hit|miss|store|invalidate|disabled].
+# La cache viene invalidata automaticamente a ogni initialize() del browser.
+DROPDOWN_CACHE=1
+
 # Non modificare queste (necessarie per Playwright in Docker)
 PYTHONUNBUFFERED=1
 DISPLAY=:99

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,11 @@ LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S=15
 # silenziosamente (il resto del servizio continua a funzionare).
 # PAGES_LOG_DIR=./logs/pages
 
+# Abilita la scrittura su disco dell'HTML di ogni pagina visitata (debug).
+# Default "1" (attivo) per backward compat; impostare "0" in produzione
+# riduce ~0.5-2s di latenza per ogni richiesta visura.
+LOG_PAGES=0
+
 # Non modificare queste (necessarie per Playwright in Docker)
 PYTHONUNBUFFERED=1
 DISPLAY=:99

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Entrambe le richieste vengono accodate ed eseguite sequenzialmente su un singolo
 
 ### Funzionalità principali
 
-- **Autenticazione SPID automatizzata** via provider Sielte ID (CIE Sign) con push notification
+- **Autenticazione SPID/SISTER automatizzata** — provider Sielte ID, PosteID o login diretto SISTER (selezionabile via `SPID_PROVIDER`)
 - **Coda sequenziale** — le richieste vengono processate una alla volta per non sovraccaricare il portale
 - **Ri-autenticazione automatica** — alla scadenza della sessione, il servizio tenta prima un recovery diretto e, solo se necessario, un nuovo login SPID
 - **Keep-alive** — la sessione viene mantenuta attiva con un light keep-alive ogni 30 secondi e un refresh profondo ogni 5 minuti
@@ -62,9 +62,23 @@ Entrambe le richieste vengono accodate ed eseguite sequenzialmente su un singolo
 - **Logging HTML completo** — ogni pagina visitata dal browser viene salvata su disco per debug e audit
 - **Docker-ready** — immagine pronta con tutte le dipendenze di sistema per Chromium headless
 
-### Compatibilità SPID
+### Provider di autenticazione supportati
 
-Il login automatizzato funziona **esclusivamente** con il provider **Sielte ID (CIE Sign)**. Il flusso prevede l'approvazione via push notification sull'app MySielteID. Altri provider SPID non sono supportati e richiederebbero modifiche alla funzione `login()` in `utils.py`.
+Il provider è selezionato dalla variabile d'ambiente `SPID_PROVIDER` (case-insensitive, default `sielte`):
+
+| `SPID_PROVIDER` | Provider | Credenziali richieste | 2° fattore |
+|-----------------|----------|------------------------|------------|
+| `sielte` (default) | SPID Sielte ID | `ADE_USERNAME`, `ADE_PASSWORD` | push notification su app MySielteID |
+| `poste` | SPID PosteID | `POSTE_USERNAME`, `POSTE_PASSWORD` | approvazione su app PosteID |
+| `sister` | Login diretto SISTER (tab dedicato sulla pagina ADE) | `SISTER_USERNAME`, `SISTER_PASSWORD` | nessuno (credenziali nominali professionali) |
+
+#### Scope d'uso ammesso per il provider `sister`
+
+> Il login diretto SISTER è destinato esclusivamente all'**intestatario della convenzione SISTER** che desidera automatizzare le proprie consultazioni con le proprie credenziali nominali.
+>
+> **Non è destinato** a chi vuole rivendere o esporre l'accesso al portale SISTER a terzi: la convenzione SISTER (Agenzia delle Entrate) richiede che l'utenza sia personale, non cedibile, e che le consultazioni siano riconducibili all'intestatario.
+>
+> Questo progetto è una libreria di automazione: la responsabilità dell'uso delle credenziali e del rispetto dei termini di convenzione resta dell'intestatario, esattamente come per il flusso SPID.
 
 ### Limitazioni note
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,10 +12,17 @@ services:
       - ./logs:/app/logs:rw
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      # `curl` non è installato nell'immagine: usiamo Python che è sempre
+      # presente. Codice di uscita 0 solo se /health risponde 200.
+      test:
+        - "CMD"
+        - "python"
+        - "-c"
+        - "import urllib.request,sys;\nr=urllib.request.urlopen('http://localhost:8000/health',timeout=5);\nsys.exit(0 if r.status==200 else 1)"
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 120s
     # Per debugging, rimuovi in produzione
     stdin_open: true
     tty: true

--- a/main.py
+++ b/main.py
@@ -151,6 +151,64 @@ class BrowserManager:
         self.authenticated = False
         self.keep_alive_running = False
         self.last_login_time = None
+        # Stats per resource blocking (popolato in initialize → context.route)
+        self.blocked_resources_count: int = 0
+        self.blocked_resources_samples: list = []  # primi N URL bloccati per diagnostica
+
+    async def _install_resource_blocking(self) -> None:
+        """Installa un route handler a livello context che blocca asset inutili.
+
+        Motivazione perf: SISTER carica 30-80 asset per pagina (logos, font,
+        icone, fogli stile esterni, talvolta tracker). La maggior parte non
+        serve all'API perché interagiamo via DOM/selettori, non visual rendering.
+        Bloccare ``image``/``font``/``media`` riduce la latenza di rete percepita
+        senza impattare ``page.evaluate`` / `get_by_role` / locator-based logic.
+
+        Diagnostica:
+          - ``RESOURCE_BLOCK=0`` disabilita il blocco (utile per debugging live
+            quando si sospetta che il blocking causi failure).
+          - ``RESOURCE_BLOCK_TYPES`` override CSV dei tipi bloccati
+            (default: ``image,font,media``). Per essere conservativi ``stylesheet``
+            NON e' bloccato di default — alcuni check di visibility Playwright
+            possono dipendere da CSS computed.
+          - Counter cumulativo (``blocked_resources_count``) + sample dei primi
+            10 URL (``blocked_resources_samples``) esposti su ``BrowserManager``
+            per ispezione via debug endpoint o log.
+          - Log per evento: ``[BLOCK] type=X url=Y`` (solo i primi 10) e
+            riepilogo periodico ``[BLOCK] cumulative=N``.
+        """
+        if os.getenv("RESOURCE_BLOCK", "1") != "1":
+            logger.info("[BLOCK] resource blocking disabilitato (RESOURCE_BLOCK=0)")
+            return
+
+        types_env = os.getenv("RESOURCE_BLOCK_TYPES", "image,font,media")
+        blocked_types = {t.strip().lower() for t in types_env.split(",") if t.strip()}
+        logger.info(f"[BLOCK] resource blocking attivo types={sorted(blocked_types)}")
+
+        async def _route_handler(route):
+            try:
+                rtype = route.request.resource_type
+                if rtype in blocked_types:
+                    self.blocked_resources_count += 1
+                    if len(self.blocked_resources_samples) < 10:
+                        sample = f"{rtype}:{route.request.url[:120]}"
+                        self.blocked_resources_samples.append(sample)
+                        logger.info(f"[BLOCK] type={rtype} url={route.request.url[:120]}")
+                    # Log periodico cumulativo ogni 200 blocchi
+                    if self.blocked_resources_count % 200 == 0:
+                        logger.info(f"[BLOCK] cumulative={self.blocked_resources_count}")
+                    await route.abort()
+                    return
+                await route.continue_()
+            except Exception as e:
+                # Non far mai rompere la richiesta a causa del blocking
+                logger.warning(f"[BLOCK] route handler error (continuing request): {e}")
+                try:
+                    await route.continue_()
+                except Exception:
+                    pass
+
+        await self.context.route("**/*", _route_handler)
 
     async def initialize(self):
         """Inizializza il browser e il contexto"""
@@ -183,6 +241,17 @@ class BrowserManager:
             )
 
             self.context = await self.browser.new_context()
+            # Reset counter + samples ad ogni init (anche su recovery)
+            self.blocked_resources_count = 0
+            self.blocked_resources_samples = []
+            await self._install_resource_blocking()
+            # Invalidate dropdown cache: nuovo context = nuove pagine SISTER fresh,
+            # le option list saranno ri-popolate alla prima richiesta.
+            try:
+                from utils import invalidate_dropdown_cache
+                invalidate_dropdown_cache(reason="browser_initialize")
+            except Exception as e:
+                logger.warning(f"invalidate_dropdown_cache failed at init: {e}")
             logger.info("Browser inizializzato")
         except Exception as e:
             logger.error(f"Failed to initialize browser: {e}")

--- a/main.py
+++ b/main.py
@@ -255,7 +255,7 @@ class BrowserManager:
             await self.auth_page.goto(
                 "https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=30000
             )
-            await self.auth_page.wait_for_load_state("networkidle", timeout=15000)
+            await self.auth_page.wait_for_load_state("domcontentloaded", timeout=15000)
 
             try:
                 provincia_options = await self.auth_page.locator("select[name='listacom'] option").count()
@@ -296,7 +296,7 @@ class BrowserManager:
                 await self.auth_page.goto(
                     "https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=30000
                 )
-                await self.auth_page.wait_for_load_state("networkidle", timeout=15000)
+                await self.auth_page.wait_for_load_state("domcontentloaded", timeout=15000)
 
             provincia_options = await self.auth_page.locator("select[name='listacom'] option").count()
             if provincia_options <= 1:
@@ -324,7 +324,7 @@ class BrowserManager:
             await self.auth_page.goto(
                 "https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=30000
             )
-            await self.auth_page.wait_for_load_state("networkidle", timeout=15000)
+            await self.auth_page.wait_for_load_state("domcontentloaded", timeout=15000)
             await recovery_logger.log(self.auth_page, "goto_scelta_servizio")
 
             current_url = self.auth_page.url
@@ -645,8 +645,10 @@ class VisuraService:
 
                 self.request_queue.task_done()
 
-                # Pausa tra le richieste per non sovraccaricare SISTER
-                await asyncio.sleep(2)
+                # Breve yield al loop per evitare burst su SISTER; il rate-limit
+                # vero è gestito dal token bucket HTTP (P1 #7). Ridotto da 2s
+                # a 0.1s per non aggiungere 2s di latenza inutile su ogni job.
+                await asyncio.sleep(0.1)
 
             except Exception as e:
                 logger.error(f"Errore nel processare richieste: {e}")

--- a/main.py
+++ b/main.py
@@ -24,14 +24,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Optional
 
+from cachetools import TTLCache
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from pydantic import BaseModel, Field, field_validator
-
-from cachetools import TTLCache
 
 from utils import PageLogger, extract_all_sezioni, login, logout, run_visura, run_visura_immobile
 
@@ -100,7 +100,9 @@ class VisuraRequest:
     sezione: Optional[str] = None
     subalterno: Optional[str] = None  # Opzionale: restringe la ricerca per fabbricati
     codice_belfiore: Optional[str] = None  # Opzionale: se valorizzato bypassa il match-by-name del comune
-    fallback_other_catasto: bool = False  # Se True e il primo tentativo NON trova nulla, riprova sull'altro catasto (T<->F)
+    fallback_other_catasto: bool = (
+        False  # Se True e il primo tentativo NON trova nulla, riprova sull'altro catasto (T<->F)
+    )
     timestamp: datetime = None
 
     def __post_init__(self):
@@ -249,6 +251,7 @@ class BrowserManager:
             # le option list saranno ri-popolate alla prima richiesta.
             try:
                 from utils import invalidate_dropdown_cache
+
                 invalidate_dropdown_cache(reason="browser_initialize")
             except Exception as e:
                 logger.warning(f"invalidate_dropdown_cache failed at init: {e}")
@@ -258,26 +261,68 @@ class BrowserManager:
             raise BrowserError(f"Browser initialization failed: {e}") from e
 
     async def login(self):
-        """Esegue il login nella prima tab"""
-        try:
-            # Chiudi la vecchia pagina prima di crearne una nuova
-            if self.auth_page and not self.auth_page.is_closed():
-                try:
-                    await self.auth_page.close()
-                    logger.info("Vecchia pagina di autenticazione chiusa")
-                except Exception as e:
-                    logger.warning(f"Errore chiudendo vecchia pagina: {e}")
+        """Esegue il login nella prima tab con retry per push SPID non approvata.
 
-            page = await self.context.new_page()
-            await login(page)
-            self.auth_page = page
-            self.authenticated = True
-            self.last_login_time = datetime.now()
-            logger.info("Login completato con successo")
-        except Exception as e:
-            logger.error(f"Errore durante il login: {e}")
-            self.authenticated = False
-            raise AuthenticationError(f"Login failed: {e}") from e
+        Distingue due classi di errore:
+
+        * ``PlaywrightTimeoutError`` — tipicamente la push SPID non e' stata
+          approvata in tempo dall'utente (timeout 120s sul click 'Autorizza'
+          per Sielte o sul redirect post-push per Poste). Ritentiamo fino a
+          ``LOGIN_MAX_ATTEMPTS`` (default 3) volte, con un breve sleep tra
+          tentativi per evitare push back-to-back.
+        * Altri errori (``RuntimeError`` fail-fast su credenziali sbagliate,
+          ``BrowserError``, ecc.) — falliscono al primo colpo perche'
+          ritentare e' inutile (le credenziali errate restano errate).
+        """
+        max_attempts = max(1, int(os.getenv("LOGIN_MAX_ATTEMPTS", "3")))
+        retry_delay_s = max(0, int(os.getenv("LOGIN_RETRY_DELAY_S", "5")))
+        last_exc: Optional[Exception] = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                # Chiudi la vecchia pagina prima di crearne una nuova
+                if self.auth_page and not self.auth_page.is_closed():
+                    try:
+                        await self.auth_page.close()
+                        logger.info("Vecchia pagina di autenticazione chiusa")
+                    except Exception as e:
+                        logger.warning(f"Errore chiudendo vecchia pagina: {e}")
+
+                page = await self.context.new_page()
+                logger.info(f"Tentativo login {attempt}/{max_attempts}")
+                await login(page)
+                self.auth_page = page
+                self.authenticated = True
+                self.last_login_time = datetime.now()
+                logger.info(f"Login completato con successo al tentativo {attempt}")
+                return
+            except PlaywrightTimeoutError as e:
+                # Push SPID non approvata in tempo — utente probabilmente
+                # distratto o push arrivata in ritardo. Ritentiamo.
+                last_exc = e
+                logger.warning(
+                    f"Tentativo login {attempt}/{max_attempts} fallito per timeout "
+                    f"(probabile push SPID non approvata): {e}"
+                )
+                self.authenticated = False
+                if attempt < max_attempts:
+                    logger.info(
+                        f"Attendo {retry_delay_s}s prima del prossimo tentativo "
+                        f"(controlla l'app SPID per la prossima notifica push)"
+                    )
+                    await asyncio.sleep(retry_delay_s)
+            except Exception as e:
+                # Errori non-timeout (credenziali errate, browser crash, ecc.):
+                # fail-fast, non ritentare.
+                logger.error(f"Errore non recuperabile durante il login: {e}")
+                self.authenticated = False
+                raise AuthenticationError(f"Login failed: {e}") from e
+
+        # Esauriti tutti i tentativi su timeout
+        logger.error(f"Login fallito dopo {max_attempts} tentativi: push SPID mai approvata")
+        raise AuthenticationError(
+            f"Login failed after {max_attempts} attempts (push SPID not approved " f"in time): {last_exc}"
+        ) from last_exc
 
     async def start_keep_alive(self):
         """Mantiene la sessione attiva con attività realistiche"""
@@ -498,10 +543,7 @@ class BrowserManager:
             fallback_used = False
             # Detect "not found": run_visura ritorna esplicitamente
             # error="NESSUNA CORRISPONDENZA TROVATA" e total_results=0 in quel caso.
-            not_found = (
-                isinstance(result, dict)
-                and result.get("error") == "NESSUNA CORRISPONDENZA TROVATA"
-            )
+            not_found = isinstance(result, dict) and result.get("error") == "NESSUNA CORRISPONDENZA TROVATA"
             if not_found and request.fallback_other_catasto:
                 other = "F" if request.tipo_catasto == "T" else "T"
                 logger.info(
@@ -515,7 +557,10 @@ class BrowserManager:
                     logger.warning(f"[FALLBACK] fallito su catasto '{other}': {e}")
                 else:
                     # Adotta il risultato del fallback solo se ha trovato qualcosa
-                    if isinstance(fallback_result, dict) and fallback_result.get("error") != "NESSUNA CORRISPONDENZA TROVATA":
+                    if (
+                        isinstance(fallback_result, dict)
+                        and fallback_result.get("error") != "NESSUNA CORRISPONDENZA TROVATA"
+                    ):
                         result = fallback_result
                         tipo_used = other
                         fallback_used = True
@@ -526,8 +571,7 @@ class BrowserManager:
                 result["fallback_used"] = fallback_used
 
             logger.info(
-                f"Visura completata per request {request.request_id} "
-                f"(tipo={tipo_used}, fallback={fallback_used})"
+                f"Visura completata per request {request.request_id} " f"(tipo={tipo_used}, fallback={fallback_used})"
             )
             return VisuraResponse(
                 request_id=request.request_id,
@@ -732,9 +776,7 @@ class VisuraService:
         try:
             self.request_queue.put_nowait({"request": request})
         except asyncio.QueueFull as e:
-            raise QueueFullError(
-                f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi"
-            ) from e
+            raise QueueFullError(f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi") from e
         logger.info(
             f"Richiesta visura {request.request_id} aggiunta alla coda (posizione: {self.request_queue.qsize()})"
         )
@@ -749,9 +791,7 @@ class VisuraService:
         try:
             self.request_queue.put_nowait({"request": request})
         except asyncio.QueueFull as e:
-            raise QueueFullError(
-                f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi"
-            ) from e
+            raise QueueFullError(f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi") from e
         logger.info(
             f"Richiesta intestati {request.request_id} aggiunta alla coda (posizione: {self.request_queue.qsize()})"
         )
@@ -846,8 +886,7 @@ async def verify_api_key_strict(api_key: str = Depends(api_key_header)):
         raise HTTPException(
             status_code=503,
             detail=(
-                "Endpoint amministrativo disabilitato: configurare la "
-                "variabile d'ambiente API_KEY per abilitarlo."
+                "Endpoint amministrativo disabilitato: configurare la " "variabile d'ambiente API_KEY per abilitarlo."
             ),
         )
     if not api_key or not secrets.compare_digest(api_key, expected_key):

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@
 import asyncio
 import logging
 import os
+import secrets
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -29,6 +30,8 @@ from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from pydantic import BaseModel, Field, validator
+
+from cachetools import TTLCache
 
 from utils import PageLogger, extract_all_sezioni, login, logout, run_visura, run_visura_immobile
 
@@ -74,6 +77,12 @@ class BrowserError(VisuraError):
     pass
 
 
+class QueueFullError(VisuraError):
+    """Raised when the request queue is at MAX_QUEUE_SIZE capacity."""
+
+    pass
+
+
 class ValidationError(VisuraError):
     """Raised when input validation fails"""
 
@@ -90,6 +99,7 @@ class VisuraRequest:
     particella: str
     sezione: Optional[str] = None
     subalterno: Optional[str] = None  # Opzionale: restringe la ricerca per fabbricati
+    codice_belfiore: Optional[str] = None  # Opzionale: se valorizzato bypassa il match-by-name del comune
     timestamp: datetime = None
 
     def __post_init__(self):
@@ -109,6 +119,7 @@ class VisuraIntestatiRequest:
     particella: str
     subalterno: Optional[str] = None
     sezione: Optional[str] = None
+    codice_belfiore: Optional[str] = None
     timestamp: datetime = None
 
     def __post_init__(self):
@@ -399,6 +410,7 @@ class BrowserManager:
                     request.tipo_catasto,
                     extract_intestati=False,
                     subalterno=request.subalterno,
+                    codice_belfiore=request.codice_belfiore,
                 )
             except Exception as e:
                 raise BrowserError(f"Failed to execute visura: {e}") from e
@@ -442,6 +454,7 @@ class BrowserManager:
                     foglio=request.foglio,
                     particella=request.particella,
                     subalterno=request.subalterno,
+                    codice_belfiore=request.codice_belfiore,
                 )
             else:
                 result = await run_visura(
@@ -453,6 +466,7 @@ class BrowserManager:
                     request.particella,
                     request.tipo_catasto,
                     extract_intestati=True,
+                    codice_belfiore=request.codice_belfiore,
                 )
 
             logger.info(f"Visura intestati completata per {request.request_id}")
@@ -531,10 +545,27 @@ class BrowserManager:
 
 
 class VisuraService:
+    # Difaults configurabili via env (vedi .env.example). Sono qui come costanti
+    # di classe così sono ispezionabili dai test senza istanziare il servizio.
+    DEFAULT_RESPONSE_TTL_SECONDS = 3600  # 1h: tempo medio entro cui il client
+    # consumer fa polling del risultato di una visura.
+    DEFAULT_RESPONSE_MAXSIZE = 10_000  # safety cap: oltre, le entry più vecchie
+    # vengono evicted (LRU dietro il TTL).
+    DEFAULT_QUEUE_MAXSIZE = 200  # backlog massimo; oltre soglia → HTTP 429.
+
     def __init__(self):
         self.browser_manager = BrowserManager()
-        self.request_queue = asyncio.Queue()
-        self.response_store: Dict[str, VisuraResponse] = {}
+
+        queue_max = int(os.getenv("MAX_QUEUE_SIZE", self.DEFAULT_QUEUE_MAXSIZE))
+        # ``asyncio.Queue`` con maxsize=0 è illimitata; usiamo il valore env.
+        self.request_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_max)
+
+        ttl_seconds = int(os.getenv("RESPONSE_TTL_SECONDS", self.DEFAULT_RESPONSE_TTL_SECONDS))
+        maxsize = int(os.getenv("RESPONSE_STORE_MAXSIZE", self.DEFAULT_RESPONSE_MAXSIZE))
+        # TTLCache: ogni entry vive ``ttl_seconds`` poi viene rimossa; se la
+        # cache supera ``maxsize`` evict LRU. Fix memory leak F5.
+        self.response_store: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+
         self.processing = False
 
     async def initialize(self):
@@ -578,16 +609,34 @@ class VisuraService:
                 await asyncio.sleep(5)
 
     async def add_request(self, request: VisuraRequest) -> str:
-        """Aggiunge una richiesta alla coda"""
-        await self.request_queue.put({"request": request})
+        """Aggiunge una richiesta alla coda.
+
+        Solleva ``QueueFullError`` se la coda è piena (vedi
+        ``MAX_QUEUE_SIZE`` env). Gli endpoint la traducono in HTTP 429.
+        """
+        try:
+            self.request_queue.put_nowait({"request": request})
+        except asyncio.QueueFull as e:
+            raise QueueFullError(
+                f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi"
+            ) from e
         logger.info(
             f"Richiesta visura {request.request_id} aggiunta alla coda (posizione: {self.request_queue.qsize()})"
         )
         return request.request_id
 
     async def add_intestati_request(self, request: VisuraIntestatiRequest) -> str:
-        """Aggiunge una richiesta intestati alla coda"""
-        await self.request_queue.put({"request": request})
+        """Aggiunge una richiesta intestati alla coda.
+
+        Solleva ``QueueFullError`` se la coda è piena (vedi
+        ``MAX_QUEUE_SIZE`` env). Gli endpoint la traducono in HTTP 429.
+        """
+        try:
+            self.request_queue.put_nowait({"request": request})
+        except asyncio.QueueFull as e:
+            raise QueueFullError(
+                f"Coda piena (limite {self.request_queue.maxsize}): riprovare più tardi"
+            ) from e
         logger.info(
             f"Richiesta intestati {request.request_id} aggiunta alla coda (posizione: {self.request_queue.qsize()})"
         )
@@ -655,12 +704,38 @@ api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
 
 
 async def verify_api_key(api_key: str = Depends(api_key_header)):
-    """Verifica che l'API Key fornita corrisponda a quella configurata."""
+    """Verifica che l'API Key fornita corrisponda a quella configurata.
+
+    Se la variabile ``API_KEY`` non è impostata in env la protezione è
+    disabilitata per gli endpoint che dipendono da questa funzione (uso "soft":
+    in dev locale è comodo non dover sempre passare la chiave). Per gli
+    endpoint amministrativi usare ``verify_api_key_strict``.
+    """
     expected_key = os.getenv("API_KEY")
     if not expected_key:
-        # Se non è configurata una API Key, la protezione è disabilitata
         return None
-    if api_key != expected_key:
+    if not api_key or not secrets.compare_digest(api_key, expected_key):
+        raise HTTPException(status_code=403, detail="API Key non valida o mancante")
+    return api_key
+
+
+async def verify_api_key_strict(api_key: str = Depends(api_key_header)):
+    """Variante fail-closed di ``verify_api_key`` per endpoint amministrativi.
+
+    Richiede sempre che ``API_KEY`` sia configurata in env e che il client
+    fornisca un header valido: se ``API_KEY`` manca l'endpoint risponde 503
+    (servizio mal configurato) invece di accettare chiamate anonime.
+    """
+    expected_key = os.getenv("API_KEY")
+    if not expected_key:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Endpoint amministrativo disabilitato: configurare la "
+                "variabile d'ambiente API_KEY per abilitarlo."
+            ),
+        )
+    if not api_key or not secrets.compare_digest(api_key, expected_key):
         raise HTTPException(status_code=403, detail="API Key non valida o mancante")
     return api_key
 
@@ -682,6 +757,15 @@ class VisuraInput(BaseModel):
     tipo_catasto: Optional[str] = Field(
         None, pattern=r"^[TF]$", description="'T' = Terreni, 'F' = Fabbricati (se omesso esegue entrambi)"
     )
+    codice_belfiore: Optional[str] = Field(
+        None,
+        pattern=r"^[A-Za-z]\d{3}$",
+        description=(
+            "Codice belfiore catastale del comune (4 char, lettera + 3 cifre, es. 'H501'). "
+            "Se valorizzato bypassa il match per nome sul dropdown SISTER ed e' piu' robusto "
+            "per comuni con varianti ortografiche tra ISTAT e SISTER."
+        ),
+    )
 
     @validator("tipo_catasto")
     def validate_tipo_catasto(cls, v):
@@ -700,6 +784,11 @@ class VisuraIntestatiInput(BaseModel):
     tipo_catasto: str = Field(..., pattern=r"^[TF]$", description="'T' = Terreni, 'F' = Fabbricati")
     subalterno: Optional[str] = Field(None, description="Numero di subalterno (obbligatorio per Fabbricati)")
     sezione: Optional[str] = Field(None, description="Sezione (opzionale)")
+    codice_belfiore: Optional[str] = Field(
+        None,
+        pattern=r"^[A-Za-z]\d{3}$",
+        description="Codice belfiore catastale del comune (vedi VisuraInput.codice_belfiore).",
+    )
 
     @validator("tipo_catasto")
     def validate_tipo_catasto(cls, v):
@@ -755,6 +844,7 @@ async def richiedi_visura(
                 foglio=request.foglio,
                 particella=request.particella,
                 subalterno=request.subalterno,
+                codice_belfiore=request.codice_belfiore,
             )
             await service.add_request(visura_req)
             request_ids.append(request_id)
@@ -770,6 +860,9 @@ async def richiedi_visura(
 
     except HTTPException:
         raise
+    except QueueFullError as e:
+        logger.warning(f"Coda piena, rifiuto richiesta visura: {e}")
+        raise HTTPException(status_code=429, detail=str(e))
     except Exception as e:
         logger.error(f"Errore nella richiesta visura: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Errore interno del server. Consulta i log per i dettagli.")
@@ -827,6 +920,7 @@ async def richiedi_intestati_immobile(
             particella=request.particella,
             subalterno=request.subalterno,
             sezione=sezione,
+            codice_belfiore=request.codice_belfiore,
         )
 
         await service.add_intestati_request(intestati_request)
@@ -844,6 +938,9 @@ async def richiedi_intestati_immobile(
 
     except HTTPException:
         raise
+    except QueueFullError as e:
+        logger.warning(f"Coda piena, rifiuto richiesta intestati: {e}")
+        raise HTTPException(status_code=429, detail=str(e))
     except Exception as e:
         logger.error(f"Errore nella richiesta intestati: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Errore interno del server. Consulta i log per i dettagli.")
@@ -863,7 +960,8 @@ async def health_check(service: VisuraService = Depends(get_visura_service)):
 
 @app.post("/shutdown")
 async def graceful_shutdown_endpoint(
-    service: VisuraService = Depends(get_visura_service), _key: str = Depends(verify_api_key)
+    service: VisuraService = Depends(get_visura_service),
+    _key: str = Depends(verify_api_key_strict),
 ):
     """Effettua uno shutdown graceful del servizio"""
     try:
@@ -879,7 +977,7 @@ async def graceful_shutdown_endpoint(
 async def extract_sezioni(
     request: SezioniExtractionRequest,
     service: VisuraService = Depends(get_visura_service),
-    _key: str = Depends(verify_api_key),
+    _key: str = Depends(verify_api_key_strict),
 ):
     """
     Estrae le sezioni territoriali d'Italia per il tipo catasto specificato.

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 from cachetools import TTLCache
 
@@ -723,7 +723,7 @@ def get_visura_service() -> VisuraService:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
-    global visura_service
+    global visura_service  # noqa: PLW0603 - FastAPI lifespan singleton pattern
     PageLogger.reset_session()  # Nuova sessione di log per ogni avvio
     visura_service = VisuraService()
     await visura_service.initialize()
@@ -820,7 +820,8 @@ class VisuraInput(BaseModel):
         ),
     )
 
-    @validator("tipo_catasto")
+    @field_validator("tipo_catasto")
+    @classmethod
     def validate_tipo_catasto(cls, v):
         if v is not None and v not in ["T", "F"]:
             raise ValidationError(f"tipo_catasto deve essere 'T' o 'F', ricevuto {v}")
@@ -843,15 +844,17 @@ class VisuraIntestatiInput(BaseModel):
         description="Codice belfiore catastale del comune (vedi VisuraInput.codice_belfiore).",
     )
 
-    @validator("tipo_catasto")
+    @field_validator("tipo_catasto")
+    @classmethod
     def validate_tipo_catasto(cls, v):
         if v not in ["T", "F"]:
             raise ValidationError(f"tipo_catasto deve essere 'T' o 'F', ricevuto {v}")
         return v
 
-    @validator("subalterno")
-    def validate_subalterno(cls, v, values):
-        tipo_catasto = values.get("tipo_catasto")
+    @field_validator("subalterno")
+    @classmethod
+    def validate_subalterno(cls, v, info):
+        tipo_catasto = info.data.get("tipo_catasto")
         if tipo_catasto == "F" and not v:
             raise ValidationError("subalterno è obbligatorio per i fabbricati (tipo_catasto='F')")
         if tipo_catasto == "T" and v:

--- a/main.py
+++ b/main.py
@@ -100,6 +100,7 @@ class VisuraRequest:
     sezione: Optional[str] = None
     subalterno: Optional[str] = None  # Opzionale: restringe la ricerca per fabbricati
     codice_belfiore: Optional[str] = None  # Opzionale: se valorizzato bypassa il match-by-name del comune
+    fallback_other_catasto: bool = False  # Se True e il primo tentativo NON trova nulla, riprova sull'altro catasto (T<->F)
     timestamp: datetime = None
 
     def __post_init__(self):
@@ -395,31 +396,74 @@ class BrowserManager:
                 raise AuthenticationError(f"Re-authentication failed: {e}") from e
 
     async def esegui_visura(self, request: VisuraRequest) -> VisuraResponse:
-        """Esegue una visura catastale (solo dati catastali, senza intestati)"""
+        """Esegue una visura catastale (solo dati catastali, senza intestati).
+
+        Se ``request.fallback_other_catasto`` e' True e il primo tentativo
+        restituisce ``NESSUNA CORRISPONDENZA TROVATA`` (total_results == 0),
+        ritenta automaticamente sull'altro catasto (T<->F) e annota
+        ``tipo_catasto_used`` e ``fallback_used`` nel campo ``data``.
+        """
         try:
             await self._ensure_authenticated()
 
-            try:
-                result = await run_visura(
+            async def _run(tipo: str):
+                return await run_visura(
                     self.auth_page,
                     request.provincia,
                     request.comune,
                     request.sezione,
                     request.foglio,
                     request.particella,
-                    request.tipo_catasto,
+                    tipo,
                     extract_intestati=False,
                     subalterno=request.subalterno,
                     codice_belfiore=request.codice_belfiore,
                 )
+
+            try:
+                result = await _run(request.tipo_catasto)
             except Exception as e:
                 raise BrowserError(f"Failed to execute visura: {e}") from e
 
-            logger.info(f"Visura completata per request {request.request_id}")
+            tipo_used = request.tipo_catasto
+            fallback_used = False
+            # Detect "not found": run_visura ritorna esplicitamente
+            # error="NESSUNA CORRISPONDENZA TROVATA" e total_results=0 in quel caso.
+            not_found = (
+                isinstance(result, dict)
+                and result.get("error") == "NESSUNA CORRISPONDENZA TROVATA"
+            )
+            if not_found and request.fallback_other_catasto:
+                other = "F" if request.tipo_catasto == "T" else "T"
+                logger.info(
+                    f"[FALLBACK] {request.request_id}: nessuna corrispondenza in "
+                    f"catasto '{request.tipo_catasto}', riprovo su '{other}'"
+                )
+                try:
+                    fallback_result = await _run(other)
+                except Exception as e:
+                    # Il fallback non deve mascherare il risultato originale: logga e tieni il primo
+                    logger.warning(f"[FALLBACK] fallito su catasto '{other}': {e}")
+                else:
+                    # Adotta il risultato del fallback solo se ha trovato qualcosa
+                    if isinstance(fallback_result, dict) and fallback_result.get("error") != "NESSUNA CORRISPONDENZA TROVATA":
+                        result = fallback_result
+                        tipo_used = other
+                        fallback_used = True
+
+            if isinstance(result, dict):
+                result["tipo_catasto_requested"] = request.tipo_catasto
+                result["tipo_catasto_used"] = tipo_used
+                result["fallback_used"] = fallback_used
+
+            logger.info(
+                f"Visura completata per request {request.request_id} "
+                f"(tipo={tipo_used}, fallback={fallback_used})"
+            )
             return VisuraResponse(
                 request_id=request.request_id,
                 success=True,
-                tipo_catasto=request.tipo_catasto,
+                tipo_catasto=tipo_used,
                 data=result,
             )
 
@@ -766,6 +810,15 @@ class VisuraInput(BaseModel):
             "per comuni con varianti ortografiche tra ISTAT e SISTER."
         ),
     )
+    fallback_other_catasto: bool = Field(
+        False,
+        description=(
+            "Se True e il primo tentativo restituisce 'NESSUNA CORRISPONDENZA TROVATA', "
+            "riprova automaticamente sull'altro catasto (T<->F). "
+            "Ha effetto solo se tipo_catasto e' valorizzato esplicitamente; quando tipo_catasto "
+            "e' omesso il backend gia' esegue T e F in parallelo come due richieste separate."
+        ),
+    )
 
     @validator("tipo_catasto")
     def validate_tipo_catasto(cls, v):
@@ -831,6 +884,9 @@ async def richiedi_visura(
         sezione = None if request.sezione == "_" else request.sezione
 
         tipos_catasto = [request.tipo_catasto] if request.tipo_catasto else ["T", "F"]
+        # Il fallback automatico ha senso solo quando l'utente specifica un singolo tipo:
+        # se omette tipo_catasto eseguiamo gia' T e F come richieste parallele indipendenti.
+        fallback_effective = bool(request.fallback_other_catasto) and request.tipo_catasto is not None
         request_ids = []
 
         for tipo_catasto in tipos_catasto:
@@ -845,6 +901,7 @@ async def richiedi_visura(
                 particella=request.particella,
                 subalterno=request.subalterno,
                 codice_belfiore=request.codice_belfiore,
+                fallback_other_catasto=fallback_effective,
             )
             await service.add_request(visura_req)
             request_ids.append(request_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pydantic>=2.10.0
 python-dotenv
 requests>=2.31.0
 email-validator
+cachetools>=5.3.0
 pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -532,7 +532,6 @@ def test_verify_api_key_uses_constant_time_compare(monkeypatch):
     assert len(calls) == 2
 
 
-
 # --- F5: TTL su response_store ---
 
 
@@ -581,12 +580,24 @@ def test_add_request_raises_queue_full_when_full(monkeypatch):
     monkeypatch.setenv("MAX_QUEUE_SIZE", "1")
     service = VisuraService()
     req1 = VisuraRequest(
-        request_id="r1", tipo_catasto="T", provincia="Trieste", comune="TRIESTE",
-        sezione=None, foglio="1", particella="1", subalterno=None,
+        request_id="r1",
+        tipo_catasto="T",
+        provincia="Trieste",
+        comune="TRIESTE",
+        sezione=None,
+        foglio="1",
+        particella="1",
+        subalterno=None,
     )
     req2 = VisuraRequest(
-        request_id="r2", tipo_catasto="T", provincia="Trieste", comune="TRIESTE",
-        sezione=None, foglio="1", particella="2", subalterno=None,
+        request_id="r2",
+        tipo_catasto="T",
+        provincia="Trieste",
+        comune="TRIESTE",
+        sezione=None,
+        foglio="1",
+        particella="2",
+        subalterno=None,
     )
     asyncio.run(service.add_request(req1))
     with pytest.raises(main.QueueFullError):
@@ -602,8 +613,13 @@ def test_richiedi_visura_returns_429_when_queue_full():
 
     service = FullService()
     request = VisuraInput(
-        provincia="Trieste", comune="TRIESTE", foglio="9", particella="166",
-        sezione="_", subalterno=None, tipo_catasto="T",
+        provincia="Trieste",
+        comune="TRIESTE",
+        foglio="9",
+        particella="166",
+        sezione="_",
+        subalterno=None,
+        tipo_catasto="T",
     )
     with pytest.raises(HTTPException) as exc:
         asyncio.run(richiedi_visura(request, service))
@@ -617,8 +633,13 @@ def test_richiedi_intestati_returns_429_when_queue_full():
 
     service = FullService()
     request = VisuraIntestatiInput(
-        provincia="Trieste", comune="TRIESTE", foglio="9", particella="166",
-        sezione="_", subalterno=None, tipo_catasto="T",
+        provincia="Trieste",
+        comune="TRIESTE",
+        foglio="9",
+        particella="166",
+        sezione="_",
+        subalterno=None,
+        tipo_catasto="T",
     )
     with pytest.raises(HTTPException) as exc:
         asyncio.run(richiedi_intestati_immobile(request, service))
@@ -627,11 +648,16 @@ def test_richiedi_intestati_returns_429_when_queue_full():
 
 # -------- P1 #6: codice_belfiore field --------
 
+
 def test_visura_input_accepts_valid_codice_belfiore():
     """H501 (Roma) e' un codice belfiore valido (lettera + 3 cifre)."""
     request = VisuraInput(
-        provincia="Roma", comune="Roma", foglio="9", particella="166",
-        tipo_catasto="T", codice_belfiore="H501",
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
+        tipo_catasto="T",
+        codice_belfiore="H501",
     )
     assert request.codice_belfiore == "H501"
 
@@ -640,45 +666,71 @@ def test_visura_input_rejects_invalid_codice_belfiore_format():
     """Formato non aderente al pattern lettera+3cifre deve fallire."""
     with pytest.raises(PydanticValidationError):
         VisuraInput(
-            provincia="Roma", comune="Roma", foglio="9", particella="166",
-            tipo_catasto="T", codice_belfiore="1234",
+            provincia="Roma",
+            comune="Roma",
+            foglio="9",
+            particella="166",
+            tipo_catasto="T",
+            codice_belfiore="1234",
         )
     with pytest.raises(PydanticValidationError):
         VisuraInput(
-            provincia="Roma", comune="Roma", foglio="9", particella="166",
-            tipo_catasto="T", codice_belfiore="HH501",
+            provincia="Roma",
+            comune="Roma",
+            foglio="9",
+            particella="166",
+            tipo_catasto="T",
+            codice_belfiore="HH501",
         )
 
 
 def test_visura_request_dataclass_carries_codice_belfiore():
     request = VisuraRequest(
-        request_id="req_1", tipo_catasto="T", provincia="Roma", comune="Roma",
-        foglio="9", particella="166", codice_belfiore="H501",
+        request_id="req_1",
+        tipo_catasto="T",
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
+        codice_belfiore="H501",
     )
     assert request.codice_belfiore == "H501"
 
 
 def test_visura_intestati_input_accepts_codice_belfiore():
     request = VisuraIntestatiInput(
-        provincia="Roma", comune="Roma", foglio="9", particella="166",
-        tipo_catasto="T", subalterno=None, codice_belfiore="H501",
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
+        tipo_catasto="T",
+        subalterno=None,
+        codice_belfiore="H501",
     )
     assert request.codice_belfiore == "H501"
 
 
 # -------- Fallback T<->F when first attempt returns NESSUNA CORRISPONDENZA --------
 
+
 def test_visura_input_accepts_fallback_other_catasto_flag():
     request = VisuraInput(
-        provincia="Roma", comune="Roma", foglio="9", particella="166",
-        tipo_catasto="T", fallback_other_catasto=True,
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
+        tipo_catasto="T",
+        fallback_other_catasto=True,
     )
     assert request.fallback_other_catasto is True
 
 
 def test_visura_input_defaults_fallback_to_false():
     request = VisuraInput(
-        provincia="Roma", comune="Roma", foglio="9", particella="166",
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
         tipo_catasto="T",
     )
     assert request.fallback_other_catasto is False
@@ -686,8 +738,13 @@ def test_visura_input_defaults_fallback_to_false():
 
 def test_visura_request_dataclass_carries_fallback_flag():
     request = VisuraRequest(
-        request_id="req_1", tipo_catasto="T", provincia="Roma", comune="Roma",
-        foglio="9", particella="166", fallback_other_catasto=True,
+        request_id="req_1",
+        tipo_catasto="T",
+        provincia="Roma",
+        comune="Roma",
+        foglio="9",
+        particella="166",
+        fallback_other_catasto=True,
     )
     assert request.fallback_other_catasto is True
 
@@ -700,10 +757,14 @@ def test_esegui_visura_falls_back_to_other_catasto_when_not_found(monkeypatch):
     async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
         calls.append(tipo)
         if tipo == "T":
-            return {"immobili": [], "results": [], "total_results": 0,
-                    "intestati": [], "error": "NESSUNA CORRISPONDENZA TROVATA"}
-        return {"immobili": [{"foo": "bar"}], "results": [{"foo": "bar"}],
-                "total_results": 1, "intestati": []}
+            return {
+                "immobili": [],
+                "results": [],
+                "total_results": 0,
+                "intestati": [],
+                "error": "NESSUNA CORRISPONDENZA TROVATA",
+            }
+        return {"immobili": [{"foo": "bar"}], "results": [{"foo": "bar"}], "total_results": 1, "intestati": []}
 
     monkeypatch.setattr("main.run_visura", fake_run_visura)
 
@@ -713,11 +774,17 @@ def test_esegui_visura_falls_back_to_other_catasto_when_not_found(monkeypatch):
 
     async def _noop():
         return None
+
     bm._ensure_authenticated = _noop  # type: ignore
 
     req = VisuraRequest(
-        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
-        foglio="1", particella="1", fallback_other_catasto=True,
+        request_id="req_test",
+        tipo_catasto="T",
+        provincia="Roma",
+        comune="Roma",
+        foglio="1",
+        particella="1",
+        fallback_other_catasto=True,
     )
     response = asyncio.run(bm.esegui_visura(req))
 
@@ -736,8 +803,13 @@ def test_esegui_visura_no_fallback_when_disabled(monkeypatch):
 
     async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
         calls.append(tipo)
-        return {"immobili": [], "results": [], "total_results": 0,
-                "intestati": [], "error": "NESSUNA CORRISPONDENZA TROVATA"}
+        return {
+            "immobili": [],
+            "results": [],
+            "total_results": 0,
+            "intestati": [],
+            "error": "NESSUNA CORRISPONDENZA TROVATA",
+        }
 
     monkeypatch.setattr("main.run_visura", fake_run_visura)
 
@@ -747,11 +819,17 @@ def test_esegui_visura_no_fallback_when_disabled(monkeypatch):
 
     async def _noop():
         return None
+
     bm._ensure_authenticated = _noop  # type: ignore
 
     req = VisuraRequest(
-        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
-        foglio="1", particella="1", fallback_other_catasto=False,
+        request_id="req_test",
+        tipo_catasto="T",
+        provincia="Roma",
+        comune="Roma",
+        foglio="1",
+        particella="1",
+        fallback_other_catasto=False,
     )
     response = asyncio.run(bm.esegui_visura(req))
 
@@ -766,8 +844,7 @@ def test_esegui_visura_no_fallback_when_first_succeeds(monkeypatch):
 
     async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
         calls.append(tipo)
-        return {"immobili": [{"x": 1}], "results": [{"x": 1}],
-                "total_results": 1, "intestati": []}
+        return {"immobili": [{"x": 1}], "results": [{"x": 1}], "total_results": 1, "intestati": []}
 
     monkeypatch.setattr("main.run_visura", fake_run_visura)
 
@@ -777,14 +854,130 @@ def test_esegui_visura_no_fallback_when_first_succeeds(monkeypatch):
 
     async def _noop():
         return None
+
     bm._ensure_authenticated = _noop  # type: ignore
 
     req = VisuraRequest(
-        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
-        foglio="1", particella="1", fallback_other_catasto=True,
+        request_id="req_test",
+        tipo_catasto="T",
+        provincia="Roma",
+        comune="Roma",
+        foglio="1",
+        particella="1",
+        fallback_other_catasto=True,
     )
     response = asyncio.run(bm.esegui_visura(req))
 
     assert calls == ["T"]
     assert response.data["tipo_catasto_used"] == "T"
     assert response.data["fallback_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Login retry on SPID push timeout (auto-relogin)
+# ---------------------------------------------------------------------------
+
+
+def test_login_retries_on_playwright_timeout(monkeypatch):
+    """Su PlaywrightTimeoutError (push SPID non approvata) il login ritenta
+    fino a LOGIN_MAX_ATTEMPTS e ha successo se l'utente approva al 2 giro."""
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+    monkeypatch.setenv("LOGIN_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("LOGIN_RETRY_DELAY_S", "0")
+
+    calls = {"login": 0}
+
+    async def fake_login(page):
+        calls["login"] += 1
+        if calls["login"] < 2:
+            raise PlaywrightTimeoutError("push non approvata")
+        return None
+
+    class FakePage:
+        def is_closed(self):
+            return False
+
+        async def close(self):
+            return None
+
+    class FakeContext:
+        async def new_page(self):
+            return FakePage()
+
+    monkeypatch.setattr("main.login", fake_login)
+    bm = main.BrowserManager()
+    bm.context = FakeContext()
+
+    asyncio.run(bm.login())
+
+    assert calls["login"] == 2
+    assert bm.authenticated is True
+
+
+def test_login_fails_fast_on_non_timeout_error(monkeypatch):
+    """Errori non-timeout (es. credenziali errate -> RuntimeError) NON ritentano."""
+    monkeypatch.setenv("LOGIN_MAX_ATTEMPTS", "5")
+    monkeypatch.setenv("LOGIN_RETRY_DELAY_S", "0")
+
+    calls = {"login": 0}
+
+    async def fake_login(page):
+        calls["login"] += 1
+        raise RuntimeError("credenziali errate")
+
+    class FakePage:
+        def is_closed(self):
+            return False
+
+        async def close(self):
+            return None
+
+    class FakeContext:
+        async def new_page(self):
+            return FakePage()
+
+    monkeypatch.setattr("main.login", fake_login)
+    bm = main.BrowserManager()
+    bm.context = FakeContext()
+
+    with pytest.raises(main.AuthenticationError):
+        asyncio.run(bm.login())
+
+    assert calls["login"] == 1
+    assert bm.authenticated is False
+
+
+def test_login_exhausts_retries_then_fails(monkeypatch):
+    """Se la push non viene mai approvata, dopo N tentativi si solleva AuthenticationError."""
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+    monkeypatch.setenv("LOGIN_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("LOGIN_RETRY_DELAY_S", "0")
+
+    calls = {"login": 0}
+
+    async def fake_login(page):
+        calls["login"] += 1
+        raise PlaywrightTimeoutError("push mai approvata")
+
+    class FakePage:
+        def is_closed(self):
+            return False
+
+        async def close(self):
+            return None
+
+    class FakeContext:
+        async def new_page(self):
+            return FakePage()
+
+    monkeypatch.setattr("main.login", fake_login)
+    bm = main.BrowserManager()
+    bm.context = FakeContext()
+
+    with pytest.raises(main.AuthenticationError):
+        asyncio.run(bm.login())
+
+    assert calls["login"] == 3
+    assert bm.authenticated is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -664,3 +664,127 @@ def test_visura_intestati_input_accepts_codice_belfiore():
         tipo_catasto="T", subalterno=None, codice_belfiore="H501",
     )
     assert request.codice_belfiore == "H501"
+
+
+# -------- Fallback T<->F when first attempt returns NESSUNA CORRISPONDENZA --------
+
+def test_visura_input_accepts_fallback_other_catasto_flag():
+    request = VisuraInput(
+        provincia="Roma", comune="Roma", foglio="9", particella="166",
+        tipo_catasto="T", fallback_other_catasto=True,
+    )
+    assert request.fallback_other_catasto is True
+
+
+def test_visura_input_defaults_fallback_to_false():
+    request = VisuraInput(
+        provincia="Roma", comune="Roma", foglio="9", particella="166",
+        tipo_catasto="T",
+    )
+    assert request.fallback_other_catasto is False
+
+
+def test_visura_request_dataclass_carries_fallback_flag():
+    request = VisuraRequest(
+        request_id="req_1", tipo_catasto="T", provincia="Roma", comune="Roma",
+        foglio="9", particella="166", fallback_other_catasto=True,
+    )
+    assert request.fallback_other_catasto is True
+
+
+def test_esegui_visura_falls_back_to_other_catasto_when_not_found(monkeypatch):
+    """Se il primo run_visura ritorna NESSUNA CORRISPONDENZA e fallback_other_catasto e' True,
+    si ritenta sull'altro tipo e si adotta il risultato se trova qualcosa."""
+    calls = []
+
+    async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
+        calls.append(tipo)
+        if tipo == "T":
+            return {"immobili": [], "results": [], "total_results": 0,
+                    "intestati": [], "error": "NESSUNA CORRISPONDENZA TROVATA"}
+        return {"immobili": [{"foo": "bar"}], "results": [{"foo": "bar"}],
+                "total_results": 1, "intestati": []}
+
+    monkeypatch.setattr("main.run_visura", fake_run_visura)
+
+    bm = main.BrowserManager()
+    bm.authenticated = True
+    bm.auth_page = object()
+
+    async def _noop():
+        return None
+    bm._ensure_authenticated = _noop  # type: ignore
+
+    req = VisuraRequest(
+        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
+        foglio="1", particella="1", fallback_other_catasto=True,
+    )
+    response = asyncio.run(bm.esegui_visura(req))
+
+    assert response.success is True
+    assert calls == ["T", "F"]
+    assert response.tipo_catasto == "F"
+    assert response.data["tipo_catasto_used"] == "F"
+    assert response.data["tipo_catasto_requested"] == "T"
+    assert response.data["fallback_used"] is True
+    assert response.data["total_results"] == 1
+
+
+def test_esegui_visura_no_fallback_when_disabled(monkeypatch):
+    """Senza fallback_other_catasto il NESSUNA CORRISPONDENZA viene mantenuto."""
+    calls = []
+
+    async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
+        calls.append(tipo)
+        return {"immobili": [], "results": [], "total_results": 0,
+                "intestati": [], "error": "NESSUNA CORRISPONDENZA TROVATA"}
+
+    monkeypatch.setattr("main.run_visura", fake_run_visura)
+
+    bm = main.BrowserManager()
+    bm.authenticated = True
+    bm.auth_page = object()
+
+    async def _noop():
+        return None
+    bm._ensure_authenticated = _noop  # type: ignore
+
+    req = VisuraRequest(
+        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
+        foglio="1", particella="1", fallback_other_catasto=False,
+    )
+    response = asyncio.run(bm.esegui_visura(req))
+
+    assert calls == ["T"]
+    assert response.data["tipo_catasto_used"] == "T"
+    assert response.data["fallback_used"] is False
+
+
+def test_esegui_visura_no_fallback_when_first_succeeds(monkeypatch):
+    """Se il primo tentativo trova risultati, il fallback non viene eseguito."""
+    calls = []
+
+    async def fake_run_visura(page, prov, com, sez, foglio, part, tipo, **kwargs):
+        calls.append(tipo)
+        return {"immobili": [{"x": 1}], "results": [{"x": 1}],
+                "total_results": 1, "intestati": []}
+
+    monkeypatch.setattr("main.run_visura", fake_run_visura)
+
+    bm = main.BrowserManager()
+    bm.authenticated = True
+    bm.auth_page = object()
+
+    async def _noop():
+        return None
+    bm._ensure_authenticated = _noop  # type: ignore
+
+    req = VisuraRequest(
+        request_id="req_test", tipo_catasto="T", provincia="Roma", comune="Roma",
+        foglio="1", particella="1", fallback_other_catasto=True,
+    )
+    response = asyncio.run(bm.esegui_visura(req))
+
+    assert calls == ["T"]
+    assert response.data["tipo_catasto_used"] == "T"
+    assert response.data["fallback_used"] is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -474,3 +474,193 @@ def test_verify_api_key_accepts_correct_header_when_enabled(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret-token")
     result = asyncio.run(main.verify_api_key(api_key="secret-token"))
     assert result == "secret-token"
+
+
+# --- F4: verify_api_key_strict (fail-closed per endpoint amministrativi) ---
+
+
+def test_verify_api_key_strict_rejects_when_env_not_set(monkeypatch):
+    """Senza API_KEY in env, lo strict mode risponde 503 anche con header valido."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.verify_api_key_strict(api_key="anything"))
+    assert exc.value.status_code == 503
+
+
+def test_verify_api_key_strict_rejects_when_env_not_set_and_no_header(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.verify_api_key_strict(api_key=None))
+    assert exc.value.status_code == 503
+
+
+def test_verify_api_key_strict_rejects_missing_header(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret-token")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.verify_api_key_strict(api_key=None))
+    assert exc.value.status_code == 403
+
+
+def test_verify_api_key_strict_rejects_wrong_header(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret-token")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.verify_api_key_strict(api_key="wrong-token"))
+    assert exc.value.status_code == 403
+
+
+def test_verify_api_key_strict_accepts_correct_header(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret-token")
+    result = asyncio.run(main.verify_api_key_strict(api_key="secret-token"))
+    assert result == "secret-token"
+
+
+def test_verify_api_key_uses_constant_time_compare(monkeypatch):
+    """F3: la verifica deve usare ``secrets.compare_digest`` (resistente a timing attack)."""
+    import secrets as _secrets
+
+    monkeypatch.setenv("API_KEY", "secret-token")
+    calls = []
+    original = _secrets.compare_digest
+
+    def _spy(a, b):
+        calls.append((a, b))
+        return original(a, b)
+
+    monkeypatch.setattr(main.secrets, "compare_digest", _spy)
+    asyncio.run(main.verify_api_key(api_key="secret-token"))
+    asyncio.run(main.verify_api_key_strict(api_key="secret-token"))
+    assert len(calls) == 2
+
+
+
+# --- F5: TTL su response_store ---
+
+
+def test_response_store_is_ttl_cache(monkeypatch):
+    """`VisuraService.response_store` deve essere una TTLCache (fix F5)."""
+    from cachetools import TTLCache
+
+    monkeypatch.setenv("RESPONSE_TTL_SECONDS", "60")
+    monkeypatch.setenv("RESPONSE_STORE_MAXSIZE", "5")
+    monkeypatch.setenv("MAX_QUEUE_SIZE", "10")
+    service = VisuraService()
+    try:
+        assert isinstance(service.response_store, TTLCache)
+        assert service.response_store.ttl == 60
+        assert service.response_store.maxsize == 5
+    finally:
+        # Evita warning su asyncio.Queue
+        pass
+
+
+def test_response_store_evicts_after_ttl():
+    """Le entry vengono rimosse dopo che il TTL è scaduto.
+
+    Smoke test contro l'implementazione reale di TTLCache: usiamo un TTL di
+    0 secondi così la prima ``expire()`` rimuove sempre l'entry.
+    """
+    from cachetools import TTLCache
+
+    cache = TTLCache(maxsize=10, ttl=0)
+    cache["a"] = "x"
+    cache.expire()
+    assert cache.get("a") is None
+
+
+# --- F10: rate-limit coda → HTTP 429 ---
+
+
+def test_request_queue_uses_max_queue_size_env(monkeypatch):
+    monkeypatch.setenv("MAX_QUEUE_SIZE", "7")
+    service = VisuraService()
+    assert service.request_queue.maxsize == 7
+
+
+def test_add_request_raises_queue_full_when_full(monkeypatch):
+    """Coda piena → QueueFullError dal service layer."""
+    monkeypatch.setenv("MAX_QUEUE_SIZE", "1")
+    service = VisuraService()
+    req1 = VisuraRequest(
+        request_id="r1", tipo_catasto="T", provincia="Trieste", comune="TRIESTE",
+        sezione=None, foglio="1", particella="1", subalterno=None,
+    )
+    req2 = VisuraRequest(
+        request_id="r2", tipo_catasto="T", provincia="Trieste", comune="TRIESTE",
+        sezione=None, foglio="1", particella="2", subalterno=None,
+    )
+    asyncio.run(service.add_request(req1))
+    with pytest.raises(main.QueueFullError):
+        asyncio.run(service.add_request(req2))
+
+
+def test_richiedi_visura_returns_429_when_queue_full():
+    """Endpoint deve restituire HTTP 429 se add_request solleva QueueFullError."""
+
+    class FullService(FakeService):
+        async def add_request(self, request):
+            raise main.QueueFullError("Coda piena (limite 1)")
+
+    service = FullService()
+    request = VisuraInput(
+        provincia="Trieste", comune="TRIESTE", foglio="9", particella="166",
+        sezione="_", subalterno=None, tipo_catasto="T",
+    )
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(richiedi_visura(request, service))
+    assert exc.value.status_code == 429
+
+
+def test_richiedi_intestati_returns_429_when_queue_full():
+    class FullService(FakeService):
+        async def add_intestati_request(self, request):
+            raise main.QueueFullError("Coda piena (limite 1)")
+
+    service = FullService()
+    request = VisuraIntestatiInput(
+        provincia="Trieste", comune="TRIESTE", foglio="9", particella="166",
+        sezione="_", subalterno=None, tipo_catasto="T",
+    )
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(richiedi_intestati_immobile(request, service))
+    assert exc.value.status_code == 429
+
+
+# -------- P1 #6: codice_belfiore field --------
+
+def test_visura_input_accepts_valid_codice_belfiore():
+    """H501 (Roma) e' un codice belfiore valido (lettera + 3 cifre)."""
+    request = VisuraInput(
+        provincia="Roma", comune="Roma", foglio="9", particella="166",
+        tipo_catasto="T", codice_belfiore="H501",
+    )
+    assert request.codice_belfiore == "H501"
+
+
+def test_visura_input_rejects_invalid_codice_belfiore_format():
+    """Formato non aderente al pattern lettera+3cifre deve fallire."""
+    with pytest.raises(PydanticValidationError):
+        VisuraInput(
+            provincia="Roma", comune="Roma", foglio="9", particella="166",
+            tipo_catasto="T", codice_belfiore="1234",
+        )
+    with pytest.raises(PydanticValidationError):
+        VisuraInput(
+            provincia="Roma", comune="Roma", foglio="9", particella="166",
+            tipo_catasto="T", codice_belfiore="HH501",
+        )
+
+
+def test_visura_request_dataclass_carries_codice_belfiore():
+    request = VisuraRequest(
+        request_id="req_1", tipo_catasto="T", provincia="Roma", comune="Roma",
+        foglio="9", particella="166", codice_belfiore="H501",
+    )
+    assert request.codice_belfiore == "H501"
+
+
+def test_visura_intestati_input_accepts_codice_belfiore():
+    request = VisuraIntestatiInput(
+        provincia="Roma", comune="Roma", foglio="9", particella="166",
+        tipo_catasto="T", subalterno=None, codice_belfiore="H501",
+    )
+    assert request.codice_belfiore == "H501"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -166,6 +166,34 @@ def test_login_provider_value_is_case_insensitive(monkeypatch):
         asyncio.run(utils.login(object()))
 
 
+def test_login_sister_provider_requires_sister_credentials(monkeypatch):
+    """SPID_PROVIDER='sister' senza SISTER_USERNAME/PASSWORD → ValueError."""
+    monkeypatch.setenv("SPID_PROVIDER", "sister")
+    monkeypatch.delenv("SISTER_USERNAME", raising=False)
+    monkeypatch.delenv("SISTER_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="SISTER_USERNAME"):
+        asyncio.run(utils.login(object()))
+
+
+def test_login_sister_provider_case_insensitive(monkeypatch):
+    """SPID_PROVIDER='SISTER' (maiuscolo) deve essere normalizzato a 'sister'."""
+    monkeypatch.setenv("SPID_PROVIDER", "SISTER")
+    monkeypatch.delenv("SISTER_USERNAME", raising=False)
+    monkeypatch.delenv("SISTER_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="SISTER_USERNAME"):
+        asyncio.run(utils.login(object()))
+
+
+def test_login_unknown_provider_error_lists_sister(monkeypatch):
+    """Il messaggio di errore deve includere 'sister' tra i valori validi."""
+    monkeypatch.setenv("SPID_PROVIDER", "lepida")
+
+    with pytest.raises(ValueError, match="sister"):
+        asyncio.run(utils.login(object()))
+
+
 def test_run_visura_immobile_requires_subalterno(monkeypatch, tmp_path):
     monkeypatch.setattr(utils, "PAGES_LOG_DIR", str(tmp_path))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,6 +200,31 @@ def test_find_best_option_match_catastal_alias_pesaro_e_urbino_to_pesaro():
     assert result == "PESARO"
 
 
+def test_find_best_option_match_catastal_alias_valle_aosta_bilingue_to_aosta():
+    """ISTAT `Valle d'Aosta/Vallée d'Aoste` (bilingue) → SISTER `AOSTA Territorio`."""
+    page = _FakePageForMatch([
+        _FakeOption("AOSTA", "AOSTA Territorio"),
+        _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Valle d'Aosta/Vallée d'Aoste")
+    )
+    assert result == "AOSTA"
+
+
+def test_find_best_option_match_catastal_alias_monza_to_milano():
+    """ISTAT `Monza e della Brianza`: SISTER non la espone, i suoi comuni sono
+    catastalmente sotto MILANO Territorio (storico pre-2009)."""
+    page = _FakePageForMatch([
+        _FakeOption("MILANO", "MILANO Territorio"),
+        _FakeOption("MANTOVA", "MANTOVA Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Monza e della Brianza")
+    )
+    assert result == "MILANO"
+
+
 def test_find_best_option_match_comune_with_grave_accent():
     """Caso F-NEW2: comune `Alì` (con accento grave) deve matchare `ALI'` / `ALI`."""
     page = _FakePageForMatch([
@@ -208,6 +233,17 @@ def test_find_best_option_match_comune_with_grave_accent():
     ])
     result = asyncio.run(utils.find_best_option_match(page, "select[name='denomComune']", "Alì"))
     assert result == "ALI'"
+
+
+def test_unsupported_provinces_sister_trento_bolzano_keys_present():
+    """Trento e Bolzano sono province autonome con Catasto Tavolare, non
+    disponibili su SISTER. Le chiavi devono essere normalizzate con
+    _normalize_for_match per essere risolte a tempo di run_visura."""
+    assert "trento" in utils._UNSUPPORTED_PROVINCES_SISTER
+    assert "bolzano" in utils._UNSUPPORTED_PROVINCES_SISTER
+    # Le ragioni contengono "Tavolare" → utile per messaggi diagnostici.
+    assert "Tavolare" in utils._UNSUPPORTED_PROVINCES_SISTER["trento"]
+    assert "Tavolare" in utils._UNSUPPORTED_PROVINCES_SISTER["bolzano"]
 
 
 def test_login_raises_when_missing_required_env(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -363,6 +363,7 @@ def test_page_logger_log_skips_closed_page(monkeypatch, tmp_path):
 
 
 def test_page_logger_log_writes_html_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOG_PAGES", "1")
     monkeypatch.setattr(utils, "PAGES_LOG_DIR", str(tmp_path))
     utils.PageLogger.reset_session()
     logger = utils.PageLogger("open")
@@ -372,6 +373,18 @@ def test_page_logger_log_writes_html_file(monkeypatch, tmp_path):
     files = os.listdir(logger.base_dir)
     assert len(files) == 1
     assert files[0].startswith("01_step_with_spaces")
+
+
+def test_page_logger_log_disabled_by_env(monkeypatch, tmp_path):
+    """LOG_PAGES=0 deve trasformare log() in no-op (gating audit 2026-05-15)."""
+    monkeypatch.setenv("LOG_PAGES", "0")
+    monkeypatch.setattr(utils, "PAGES_LOG_DIR", str(tmp_path))
+    utils.PageLogger.reset_session()
+    logger = utils.PageLogger("open")
+
+    asyncio.run(logger.log(_FakePageOpen(), "step"))
+
+    assert os.listdir(logger.base_dir) == []
 
 
 def test_resolve_pages_log_dir_uses_env_var_when_set(monkeypatch, tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,6 +176,30 @@ def test_find_best_option_match_catastal_alias_verbano_to_verbania():
     assert result == "VERBANIA"
 
 
+def test_find_best_option_match_catastal_alias_sud_sardegna_to_cagliari():
+    """Sud Sardegna (istituita 2016) → SISTER la mappa sotto CAGLIARI."""
+    page = _FakePageForMatch([
+        _FakeOption("CAGLIARI", "CAGLIARI Territorio"),
+        _FakeOption("CALTANISSETTA", "CALTANISSETTA Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Sud Sardegna")
+    )
+    assert result == "CAGLIARI"
+
+
+def test_find_best_option_match_catastal_alias_pesaro_e_urbino_to_pesaro():
+    """ISTAT `Pesaro e Urbino` → SISTER `PESARO Territorio`."""
+    page = _FakePageForMatch([
+        _FakeOption("PESARO", "PESARO Territorio"),
+        _FakeOption("PERUGIA", "PERUGIA Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Pesaro e Urbino")
+    )
+    assert result == "PESARO"
+
+
 def test_find_best_option_match_comune_with_grave_accent():
     """Caso F-NEW2: comune `Alì` (con accento grave) deve matchare `ALI'` / `ALI`."""
     page = _FakePageForMatch([

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,7 @@ def test_find_best_option_match_returns_none_when_no_match():
 
 # --- F-NEW1/F-NEW2: normalizzazione provincia/comune SISTER -----------------
 
+
 def test_normalize_strips_accents_and_apostrophes():
     assert utils._normalize_for_match("L'Aquila") == "l aquila"
     assert utils._normalize_for_match("L\u2019AQUILA Territorio") == "l aquila"
@@ -152,11 +153,13 @@ def test_normalize_strips_territorio_suffix():
 
 def test_find_best_option_match_handles_aquila_with_apostrophe():
     """Caso F-NEW1: input ISTAT `L'Aquila`, option SISTER `L'AQUILA Territorio`."""
-    page = _FakePageForMatch([
-        _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
-        _FakeOption("L'AQUILA", "L'AQUILA Territorio"),
-        _FakeOption("AOSTA", "AOSTA Territorio"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
+            _FakeOption("L'AQUILA", "L'AQUILA Territorio"),
+            _FakeOption("AOSTA", "AOSTA Territorio"),
+        ]
+    )
     result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "L'Aquila"))
     assert result == "L'AQUILA"
 
@@ -171,84 +174,86 @@ def test_find_best_option_match_handles_typographic_apostrophe():
 def test_find_best_option_match_handles_reggio_emilia():
     """Caso live: ISTAT espone `Reggio nell'Emilia` ma SISTER mostra solo
     `REGGIO EMILIA Territorio`. Risolto tramite alias catastale."""
-    page = _FakePageForMatch([
-        _FakeOption("REGGIO EMILIA", "REGGIO EMILIA Territorio"),
-        _FakeOption("REGGIO CALABRIA", "REGGIO CALABRIA Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Reggio nell'Emilia")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("REGGIO EMILIA", "REGGIO EMILIA Territorio"),
+            _FakeOption("REGGIO CALABRIA", "REGGIO CALABRIA Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Reggio nell'Emilia"))
     assert result == "REGGIO EMILIA"
 
 
 def test_find_best_option_match_catastal_alias_verbano_to_verbania():
     """Caso F-NEW1: ISTAT `Verbano-Cusio-Ossola` → catasto `Verbania`."""
-    page = _FakePageForMatch([
-        _FakeOption("VARESE", "VARESE Territorio"),
-        _FakeOption("VERBANIA", "VERBANIA Territorio"),
-        _FakeOption("VERCELLI", "VERCELLI Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Verbano-Cusio-Ossola")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("VARESE", "VARESE Territorio"),
+            _FakeOption("VERBANIA", "VERBANIA Territorio"),
+            _FakeOption("VERCELLI", "VERCELLI Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Verbano-Cusio-Ossola"))
     assert result == "VERBANIA"
 
 
 def test_find_best_option_match_catastal_alias_sud_sardegna_to_cagliari():
     """Sud Sardegna (istituita 2016) → SISTER la mappa sotto CAGLIARI."""
-    page = _FakePageForMatch([
-        _FakeOption("CAGLIARI", "CAGLIARI Territorio"),
-        _FakeOption("CALTANISSETTA", "CALTANISSETTA Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Sud Sardegna")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("CAGLIARI", "CAGLIARI Territorio"),
+            _FakeOption("CALTANISSETTA", "CALTANISSETTA Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Sud Sardegna"))
     assert result == "CAGLIARI"
 
 
 def test_find_best_option_match_catastal_alias_pesaro_e_urbino_to_pesaro():
     """ISTAT `Pesaro e Urbino` → SISTER `PESARO Territorio`."""
-    page = _FakePageForMatch([
-        _FakeOption("PESARO", "PESARO Territorio"),
-        _FakeOption("PERUGIA", "PERUGIA Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Pesaro e Urbino")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("PESARO", "PESARO Territorio"),
+            _FakeOption("PERUGIA", "PERUGIA Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Pesaro e Urbino"))
     assert result == "PESARO"
 
 
 def test_find_best_option_match_catastal_alias_valle_aosta_bilingue_to_aosta():
     """ISTAT `Valle d'Aosta/Vallée d'Aoste` (bilingue) → SISTER `AOSTA Territorio`."""
-    page = _FakePageForMatch([
-        _FakeOption("AOSTA", "AOSTA Territorio"),
-        _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Valle d'Aosta/Vallée d'Aoste")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("AOSTA", "AOSTA Territorio"),
+            _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Valle d'Aosta/Vallée d'Aoste"))
     assert result == "AOSTA"
 
 
 def test_find_best_option_match_catastal_alias_monza_to_milano():
     """ISTAT `Monza e della Brianza`: SISTER non la espone, i suoi comuni sono
     catastalmente sotto MILANO Territorio (storico pre-2009)."""
-    page = _FakePageForMatch([
-        _FakeOption("MILANO", "MILANO Territorio"),
-        _FakeOption("MANTOVA", "MANTOVA Territorio"),
-    ])
-    result = asyncio.run(
-        utils.find_best_option_match(page, "select[name='listacom']", "Monza e della Brianza")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("MILANO", "MILANO Territorio"),
+            _FakeOption("MANTOVA", "MANTOVA Territorio"),
+        ]
     )
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "Monza e della Brianza"))
     assert result == "MILANO"
 
 
 def test_find_best_option_match_comune_with_grave_accent():
     """Caso F-NEW2: comune `Alì` (con accento grave) deve matchare `ALI'` / `ALI`."""
-    page = _FakePageForMatch([
-        _FakeOption("ALI'", "ALI'"),
-        _FakeOption("ALI TERME", "ALI' TERME"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("ALI'", "ALI'"),
+            _FakeOption("ALI TERME", "ALI' TERME"),
+        ]
+    )
     result = asyncio.run(utils.find_best_option_match(page, "select[name='denomComune']", "Alì"))
     assert result == "ALI'"
 
@@ -454,32 +459,29 @@ def test_page_logger_disabled_when_no_writable_dir(monkeypatch):
 
 # -------- P1 #6: find_option_by_codice_belfiore --------
 
+
 def test_find_option_by_codice_belfiore_returns_value_with_prefix():
     """SISTER option value format: 'CODICE#NOME#0#0' (es. H501#ROMA#0#0)."""
-    page = _FakePageForMatch([
-        _FakeOption("A737#BELFIORE#0#0", "BELFIORE"),
-        _FakeOption("H501#ROMA#0#0", "ROMA"),
-        _FakeOption("F839#CASANDRINO#0#0", "CASANDRINO"),
-    ])
-    result = asyncio.run(
-        utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "H501")
+    page = _FakePageForMatch(
+        [
+            _FakeOption("A737#BELFIORE#0#0", "BELFIORE"),
+            _FakeOption("H501#ROMA#0#0", "ROMA"),
+            _FakeOption("F839#CASANDRINO#0#0", "CASANDRINO"),
+        ]
     )
+    result = asyncio.run(utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "H501"))
     assert result == "H501#ROMA#0#0"
 
 
 def test_find_option_by_codice_belfiore_is_case_insensitive():
     page = _FakePageForMatch([_FakeOption("H501#ROMA#0#0", "ROMA")])
-    result = asyncio.run(
-        utils.find_option_by_codice_belfiore(page, "sel", "h501")
-    )
+    result = asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "h501"))
     assert result == "H501#ROMA#0#0"
 
 
 def test_find_option_by_codice_belfiore_returns_none_on_missing():
     page = _FakePageForMatch([_FakeOption("A737#BELFIORE#0#0", "BELFIORE")])
-    result = asyncio.run(
-        utils.find_option_by_codice_belfiore(page, "sel", "Z999")
-    )
+    result = asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "Z999"))
     assert result is None
 
 
@@ -492,13 +494,16 @@ def test_find_option_by_codice_belfiore_returns_none_on_empty_input():
 
 # -------- MVP-2: dropdown cache + _collect_options_fast --------
 
+
 def test_collect_options_fast_returns_value_text_tuples():
     """Single page.evaluate path: ritorna lista di (value, text) normalizzata."""
-    page = _FakePageForMatch([
-        _FakeOption("V1", "  T1  "),
-        _FakeOption("V2", "T2"),
-        _FakeOption("", "skipped_text_only"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("V1", "  T1  "),
+            _FakeOption("V2", "T2"),
+            _FakeOption("", "skipped_text_only"),
+        ]
+    )
     items = asyncio.run(utils._collect_options_fast(page, "any"))
     # Il fake evaluate fa strip() su text; value vuoto resta vuoto
     assert items == [("V1", "T1"), ("V2", "T2"), ("", "skipped_text_only")]
@@ -518,9 +523,11 @@ def test_dropdown_cache_province_hit_avoids_second_evaluate(monkeypatch):
     # Conta quante volte _collect_options_fast viene chiamato
     calls = {"n": 0}
     real = utils._collect_options_fast
+
     async def counting(p, s):
         calls["n"] += 1
         return await real(p, s)
+
     monkeypatch.setattr(utils, "_collect_options_fast", counting)
 
     r1 = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
@@ -537,9 +544,11 @@ def test_dropdown_cache_disabled_refetches_each_time(monkeypatch):
 
     calls = {"n": 0}
     real = utils._collect_options_fast
+
     async def counting(p, s):
         calls["n"] += 1
         return await real(p, s)
+
     monkeypatch.setattr(utils, "_collect_options_fast", counting)
 
     asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
@@ -551,18 +560,22 @@ def test_find_option_by_codice_belfiore_no_cache_when_provincia_unknown(monkeypa
     """Il path comune con provincia_value=None NON deve cachare (evita cross-province
     poisoning, regressione 2026-05-15: Mantova comuni riusati per Savona/Pesaro).
     Aspettato: una evaluate per chiamata."""
-    page = _FakePageForMatch([
-        _FakeOption("H501#ROMA#0#0", "ROMA"),
-        _FakeOption("F205#MILANO#0#0", "MILANO"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("H501#ROMA#0#0", "ROMA"),
+            _FakeOption("F205#MILANO#0#0", "MILANO"),
+        ]
+    )
     monkeypatch.setenv("DROPDOWN_CACHE", "1")
     utils.invalidate_dropdown_cache(reason="test_setup")
 
     calls = {"n": 0}
     real = utils._collect_options_fast
+
     async def counting(p, s):
         calls["n"] += 1
         return await real(p, s)
+
     monkeypatch.setattr(utils, "_collect_options_fast", counting)
 
     r1 = asyncio.run(utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "H501"))
@@ -580,32 +593,45 @@ def test_comune_cache_scoped_by_provincia(monkeypatch):
     - stessa provincia → 1 evaluate per 2 lookup (cache hit)
     - provincia diversa → 2 evaluate per 2 lookup (chiave diversa, no poisoning)
     """
-    page = _FakePageForMatch([
-        _FakeOption("H501#ROMA#0#0", "ROMA"),
-        _FakeOption("F205#MILANO#0#0", "MILANO"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("H501#ROMA#0#0", "ROMA"),
+            _FakeOption("F205#MILANO#0#0", "MILANO"),
+        ]
+    )
     monkeypatch.setenv("DROPDOWN_CACHE", "1")
     utils.invalidate_dropdown_cache(reason="test_setup")
 
     calls = {"n": 0}
     real = utils._collect_options_fast
+
     async def counting(p, s):
         calls["n"] += 1
         return await real(p, s)
+
     monkeypatch.setattr(utils, "_collect_options_fast", counting)
 
     # Stessa provincia → seconda chiamata cache hit
-    r1 = asyncio.run(utils.find_option_by_codice_belfiore(
-        page, "select[name='denomComune']", "H501", provincia_value="ROMA Territorio-RM"))
-    r2 = asyncio.run(utils.find_option_by_codice_belfiore(
-        page, "select[name='denomComune']", "F205", provincia_value="ROMA Territorio-RM"))
+    r1 = asyncio.run(
+        utils.find_option_by_codice_belfiore(
+            page, "select[name='denomComune']", "H501", provincia_value="ROMA Territorio-RM"
+        )
+    )
+    r2 = asyncio.run(
+        utils.find_option_by_codice_belfiore(
+            page, "select[name='denomComune']", "F205", provincia_value="ROMA Territorio-RM"
+        )
+    )
     assert r1 == "H501#ROMA#0#0"
     assert r2 == "F205#MILANO#0#0"
     assert calls["n"] == 1, f"expected 1 evaluate (same provincia), got {calls['n']}"
 
     # Provincia diversa → cache miss separata (no poisoning)
-    r3 = asyncio.run(utils.find_option_by_codice_belfiore(
-        page, "select[name='denomComune']", "H501", provincia_value="MILANO Territorio-MI"))
+    r3 = asyncio.run(
+        utils.find_option_by_codice_belfiore(
+            page, "select[name='denomComune']", "H501", provincia_value="MILANO Territorio-MI"
+        )
+    )
     assert r3 == "H501#ROMA#0#0"
     assert calls["n"] == 2, f"expected 2 evaluate (diff provincia), got {calls['n']}"
 
@@ -617,24 +643,30 @@ def test_comune_cache_scoped_by_provincia(monkeypatch):
 def test_find_best_option_match_comune_uses_provincia_scoped_cache(monkeypatch):
     """find_best_option_match con provincia_value valorizzato sfrutta la cache
     comune scoped, senza cross-province poisoning."""
-    page = _FakePageForMatch([
-        _FakeOption("H501#ROMA#0#0", "ROMA"),
-        _FakeOption("F205#MILANO#0#0", "MILANO"),
-    ])
+    page = _FakePageForMatch(
+        [
+            _FakeOption("H501#ROMA#0#0", "ROMA"),
+            _FakeOption("F205#MILANO#0#0", "MILANO"),
+        ]
+    )
     monkeypatch.setenv("DROPDOWN_CACHE", "1")
     utils.invalidate_dropdown_cache(reason="test_setup")
 
     calls = {"n": 0}
     real = utils._collect_options_fast
+
     async def counting(p, s):
         calls["n"] += 1
         return await real(p, s)
+
     monkeypatch.setattr(utils, "_collect_options_fast", counting)
 
-    r1 = asyncio.run(utils.find_best_option_match(
-        page, "select[name='denomComune']", "ROMA", provincia_value="ROMA Territorio-RM"))
-    r2 = asyncio.run(utils.find_best_option_match(
-        page, "select[name='denomComune']", "MILANO", provincia_value="ROMA Territorio-RM"))
+    r1 = asyncio.run(
+        utils.find_best_option_match(page, "select[name='denomComune']", "ROMA", provincia_value="ROMA Territorio-RM")
+    )
+    r2 = asyncio.run(
+        utils.find_best_option_match(page, "select[name='denomComune']", "MILANO", provincia_value="ROMA Territorio-RM")
+    )
     assert r1 == "H501#ROMA#0#0"
     assert r2 == "F205#MILANO#0#0"
     assert calls["n"] == 1, f"expected 1 evaluate (cache hit by provincia), got {calls['n']}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,75 @@ def test_find_best_option_match_returns_none_when_no_match():
     assert result is None
 
 
+# --- F-NEW1/F-NEW2: normalizzazione provincia/comune SISTER -----------------
+
+def test_normalize_strips_accents_and_apostrophes():
+    assert utils._normalize_for_match("L'Aquila") == "l aquila"
+    assert utils._normalize_for_match("L\u2019AQUILA Territorio") == "l aquila"
+    assert utils._normalize_for_match("Alì") == "ali"
+    assert utils._normalize_for_match("Forlì-Cesena") == "forli cesena"
+
+
+def test_normalize_strips_territorio_suffix():
+    assert utils._normalize_for_match("ALESSANDRIA Territorio") == "alessandria"
+    # Anche con doppio spazio / case mista
+    assert utils._normalize_for_match("Reggio nell'Emilia Territorio") == "reggio nell emilia"
+
+
+def test_find_best_option_match_handles_aquila_with_apostrophe():
+    """Caso F-NEW1: input ISTAT `L'Aquila`, option SISTER `L'AQUILA Territorio`."""
+    page = _FakePageForMatch([
+        _FakeOption("ALESSANDRIA", "ALESSANDRIA Territorio"),
+        _FakeOption("L'AQUILA", "L'AQUILA Territorio"),
+        _FakeOption("AOSTA", "AOSTA Territorio"),
+    ])
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "L'Aquila"))
+    assert result == "L'AQUILA"
+
+
+def test_find_best_option_match_handles_typographic_apostrophe():
+    """Caso F-NEW1: SISTER usa apostrofo tipografico ’ invece dell'ASCII '."""
+    page = _FakePageForMatch([_FakeOption("L'AQUILA", "L\u2019AQUILA Territorio")])
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "L'Aquila"))
+    assert result == "L'AQUILA"
+
+
+def test_find_best_option_match_handles_reggio_emilia():
+    """Caso live: ISTAT espone `Reggio nell'Emilia` ma SISTER mostra solo
+    `REGGIO EMILIA Territorio`. Risolto tramite alias catastale."""
+    page = _FakePageForMatch([
+        _FakeOption("REGGIO EMILIA", "REGGIO EMILIA Territorio"),
+        _FakeOption("REGGIO CALABRIA", "REGGIO CALABRIA Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Reggio nell'Emilia")
+    )
+    assert result == "REGGIO EMILIA"
+
+
+def test_find_best_option_match_catastal_alias_verbano_to_verbania():
+    """Caso F-NEW1: ISTAT `Verbano-Cusio-Ossola` → catasto `Verbania`."""
+    page = _FakePageForMatch([
+        _FakeOption("VARESE", "VARESE Territorio"),
+        _FakeOption("VERBANIA", "VERBANIA Territorio"),
+        _FakeOption("VERCELLI", "VERCELLI Territorio"),
+    ])
+    result = asyncio.run(
+        utils.find_best_option_match(page, "select[name='listacom']", "Verbano-Cusio-Ossola")
+    )
+    assert result == "VERBANIA"
+
+
+def test_find_best_option_match_comune_with_grave_accent():
+    """Caso F-NEW2: comune `Alì` (con accento grave) deve matchare `ALI'` / `ALI`."""
+    page = _FakePageForMatch([
+        _FakeOption("ALI'", "ALI'"),
+        _FakeOption("ALI TERME", "ALI' TERME"),
+    ])
+    result = asyncio.run(utils.find_best_option_match(page, "select[name='denomComune']", "Alì"))
+    assert result == "ALI'"
+
+
 def test_login_raises_when_missing_required_env(monkeypatch):
     monkeypatch.delenv("SPID_PROVIDER", raising=False)
     monkeypatch.delenv("ADE_USERNAME", raising=False)
@@ -290,3 +359,41 @@ def test_page_logger_disabled_when_no_writable_dir(monkeypatch):
     # ``log()`` deve essere no-op senza sollevare eccezioni
     asyncio.run(logger.log(_FakePageOpen(), "any"))
     assert logger.step == 1
+
+
+# -------- P1 #6: find_option_by_codice_belfiore --------
+
+def test_find_option_by_codice_belfiore_returns_value_with_prefix():
+    """SISTER option value format: 'CODICE#NOME#0#0' (es. H501#ROMA#0#0)."""
+    page = _FakePageForMatch([
+        _FakeOption("A737#BELFIORE#0#0", "BELFIORE"),
+        _FakeOption("H501#ROMA#0#0", "ROMA"),
+        _FakeOption("F839#CASANDRINO#0#0", "CASANDRINO"),
+    ])
+    result = asyncio.run(
+        utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "H501")
+    )
+    assert result == "H501#ROMA#0#0"
+
+
+def test_find_option_by_codice_belfiore_is_case_insensitive():
+    page = _FakePageForMatch([_FakeOption("H501#ROMA#0#0", "ROMA")])
+    result = asyncio.run(
+        utils.find_option_by_codice_belfiore(page, "sel", "h501")
+    )
+    assert result == "H501#ROMA#0#0"
+
+
+def test_find_option_by_codice_belfiore_returns_none_on_missing():
+    page = _FakePageForMatch([_FakeOption("A737#BELFIORE#0#0", "BELFIORE")])
+    result = asyncio.run(
+        utils.find_option_by_codice_belfiore(page, "sel", "Z999")
+    )
+    assert result is None
+
+
+def test_find_option_by_codice_belfiore_returns_none_on_empty_input():
+    page = _FakePageForMatch([_FakeOption("H501#ROMA#0#0", "ROMA")])
+    assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "")) is None
+    assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "   ")) is None
+    assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", None)) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -575,6 +575,71 @@ def test_find_option_by_codice_belfiore_no_cache_when_provincia_unknown(monkeypa
     assert not any(k[0] == "comune" for k in utils._DROPDOWN_CACHE.keys())
 
 
+def test_comune_cache_scoped_by_provincia(monkeypatch):
+    """Con provincia_value valorizzato la cache comune deve essere safe E attiva:
+    - stessa provincia → 1 evaluate per 2 lookup (cache hit)
+    - provincia diversa → 2 evaluate per 2 lookup (chiave diversa, no poisoning)
+    """
+    page = _FakePageForMatch([
+        _FakeOption("H501#ROMA#0#0", "ROMA"),
+        _FakeOption("F205#MILANO#0#0", "MILANO"),
+    ])
+    monkeypatch.setenv("DROPDOWN_CACHE", "1")
+    utils.invalidate_dropdown_cache(reason="test_setup")
+
+    calls = {"n": 0}
+    real = utils._collect_options_fast
+    async def counting(p, s):
+        calls["n"] += 1
+        return await real(p, s)
+    monkeypatch.setattr(utils, "_collect_options_fast", counting)
+
+    # Stessa provincia → seconda chiamata cache hit
+    r1 = asyncio.run(utils.find_option_by_codice_belfiore(
+        page, "select[name='denomComune']", "H501", provincia_value="ROMA Territorio-RM"))
+    r2 = asyncio.run(utils.find_option_by_codice_belfiore(
+        page, "select[name='denomComune']", "F205", provincia_value="ROMA Territorio-RM"))
+    assert r1 == "H501#ROMA#0#0"
+    assert r2 == "F205#MILANO#0#0"
+    assert calls["n"] == 1, f"expected 1 evaluate (same provincia), got {calls['n']}"
+
+    # Provincia diversa → cache miss separata (no poisoning)
+    r3 = asyncio.run(utils.find_option_by_codice_belfiore(
+        page, "select[name='denomComune']", "H501", provincia_value="MILANO Territorio-MI"))
+    assert r3 == "H501#ROMA#0#0"
+    assert calls["n"] == 2, f"expected 2 evaluate (diff provincia), got {calls['n']}"
+
+    # Chiavi cache distinte per provincia
+    keys = {k for k in utils._DROPDOWN_CACHE.keys() if k[0] == "comune"}
+    assert keys == {("comune", "ROMA Territorio-RM"), ("comune", "MILANO Territorio-MI")}
+
+
+def test_find_best_option_match_comune_uses_provincia_scoped_cache(monkeypatch):
+    """find_best_option_match con provincia_value valorizzato sfrutta la cache
+    comune scoped, senza cross-province poisoning."""
+    page = _FakePageForMatch([
+        _FakeOption("H501#ROMA#0#0", "ROMA"),
+        _FakeOption("F205#MILANO#0#0", "MILANO"),
+    ])
+    monkeypatch.setenv("DROPDOWN_CACHE", "1")
+    utils.invalidate_dropdown_cache(reason="test_setup")
+
+    calls = {"n": 0}
+    real = utils._collect_options_fast
+    async def counting(p, s):
+        calls["n"] += 1
+        return await real(p, s)
+    monkeypatch.setattr(utils, "_collect_options_fast", counting)
+
+    r1 = asyncio.run(utils.find_best_option_match(
+        page, "select[name='denomComune']", "ROMA", provincia_value="ROMA Territorio-RM"))
+    r2 = asyncio.run(utils.find_best_option_match(
+        page, "select[name='denomComune']", "MILANO", provincia_value="ROMA Territorio-RM"))
+    assert r1 == "H501#ROMA#0#0"
+    assert r2 == "F205#MILANO#0#0"
+    assert calls["n"] == 1, f"expected 1 evaluate (cache hit by provincia), got {calls['n']}"
+
+
 def test_invalidate_dropdown_cache_clears_state():
     utils._DROPDOWN_CACHE[("province",)] = {"items": [], "by_norm": {}}
     utils._DROPDOWN_CACHE[("comune", "")] = {"items": [], "by_norm": {}, "by_belfiore": {}}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -547,8 +547,10 @@ def test_dropdown_cache_disabled_refetches_each_time(monkeypatch):
     assert calls["n"] == 2, f"expected 2 evaluate calls (cache off), got {calls['n']}"
 
 
-def test_find_option_by_codice_belfiore_uses_comune_cache(monkeypatch):
-    """Il path comune (select[name='denomComune']) deve passare dalla cache."""
+def test_find_option_by_codice_belfiore_no_cache_when_provincia_unknown(monkeypatch):
+    """Il path comune con provincia_value=None NON deve cachare (evita cross-province
+    poisoning, regressione 2026-05-15: Mantova comuni riusati per Savona/Pesaro).
+    Aspettato: una evaluate per chiamata."""
     page = _FakePageForMatch([
         _FakeOption("H501#ROMA#0#0", "ROMA"),
         _FakeOption("F205#MILANO#0#0", "MILANO"),
@@ -567,8 +569,10 @@ def test_find_option_by_codice_belfiore_uses_comune_cache(monkeypatch):
     r2 = asyncio.run(utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "F205"))
     assert r1 == "H501#ROMA#0#0"
     assert r2 == "F205#MILANO#0#0"
-    # Una sola evaluate: la seconda lookup serve dalla stessa cache
-    assert calls["n"] == 1, f"expected 1 evaluate call, got {calls['n']}"
+    # Due evaluate: nessuna cache senza provincia_value
+    assert calls["n"] == 2, f"expected 2 evaluate calls (no provincia_value), got {calls['n']}"
+    # Nessuna entry comune cachata
+    assert not any(k[0] == "comune" for k in utils._DROPDOWN_CACHE.keys())
 
 
 def test_invalidate_dropdown_cache_clears_state():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,14 @@ import utils
 from utils import parse_table
 
 
+@pytest.fixture(autouse=True)
+def _clear_dropdown_cache():
+    """Svuota la cache dropdown tra ogni test per evitare pollution cross-test."""
+    utils.invalidate_dropdown_cache(reason="pytest_fixture")
+    yield
+    utils.invalidate_dropdown_cache(reason="pytest_fixture_teardown")
+
+
 def test_parse_table_extracts_rows_and_columns():
     html = """
     <table>
@@ -71,6 +79,16 @@ class _FakePageForMatch:
 
     def locator(self, _selector):
         return _FakeLocator(self._options)
+
+    async def evaluate(self, _script, _selector=None):
+        # Simula il page.evaluate usato da _collect_options_fast: ritorna
+        # [[value, text], ...] in modo coerente con i fake options.
+        out = []
+        for opt in self._options:
+            v = await opt.get_attribute("value")
+            t = await opt.inner_text()
+            out.append([v or "", (t or "").strip()])
+        return out
 
 
 class _FakePageClosed:
@@ -470,3 +488,91 @@ def test_find_option_by_codice_belfiore_returns_none_on_empty_input():
     assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "")) is None
     assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", "   ")) is None
     assert asyncio.run(utils.find_option_by_codice_belfiore(page, "sel", None)) is None
+
+
+# -------- MVP-2: dropdown cache + _collect_options_fast --------
+
+def test_collect_options_fast_returns_value_text_tuples():
+    """Single page.evaluate path: ritorna lista di (value, text) normalizzata."""
+    page = _FakePageForMatch([
+        _FakeOption("V1", "  T1  "),
+        _FakeOption("V2", "T2"),
+        _FakeOption("", "skipped_text_only"),
+    ])
+    items = asyncio.run(utils._collect_options_fast(page, "any"))
+    # Il fake evaluate fa strip() su text; value vuoto resta vuoto
+    assert items == [("V1", "T1"), ("V2", "T2"), ("", "skipped_text_only")]
+
+
+def test_format_options_for_debug_filters_empty():
+    items = [("V1", "T1"), ("", "T_no_value"), ("V3", ""), ("V4", "T4")]
+    assert utils._format_options_for_debug(items) == ["T1 (V1)", "T4 (V4)"]
+
+
+def test_dropdown_cache_province_hit_avoids_second_evaluate(monkeypatch):
+    """Seconda lookup sulla stessa provincia deve usare la cache (no re-evaluate)."""
+    page = _FakePageForMatch([_FakeOption("RM", "ROMA"), _FakeOption("MI", "MILANO")])
+    monkeypatch.setenv("DROPDOWN_CACHE", "1")
+    utils.invalidate_dropdown_cache(reason="test_setup")
+
+    # Conta quante volte _collect_options_fast viene chiamato
+    calls = {"n": 0}
+    real = utils._collect_options_fast
+    async def counting(p, s):
+        calls["n"] += 1
+        return await real(p, s)
+    monkeypatch.setattr(utils, "_collect_options_fast", counting)
+
+    r1 = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
+    r2 = asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
+    assert r1 == "RM" and r2 == "RM"
+    # Solo una chiamata: la seconda risolve via cache by_norm
+    assert calls["n"] == 1, f"expected 1 evaluate call, got {calls['n']}"
+
+
+def test_dropdown_cache_disabled_refetches_each_time(monkeypatch):
+    page = _FakePageForMatch([_FakeOption("RM", "ROMA")])
+    monkeypatch.setenv("DROPDOWN_CACHE", "0")
+    utils.invalidate_dropdown_cache(reason="test_setup")
+
+    calls = {"n": 0}
+    real = utils._collect_options_fast
+    async def counting(p, s):
+        calls["n"] += 1
+        return await real(p, s)
+    monkeypatch.setattr(utils, "_collect_options_fast", counting)
+
+    asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
+    asyncio.run(utils.find_best_option_match(page, "select[name='listacom']", "ROMA"))
+    assert calls["n"] == 2, f"expected 2 evaluate calls (cache off), got {calls['n']}"
+
+
+def test_find_option_by_codice_belfiore_uses_comune_cache(monkeypatch):
+    """Il path comune (select[name='denomComune']) deve passare dalla cache."""
+    page = _FakePageForMatch([
+        _FakeOption("H501#ROMA#0#0", "ROMA"),
+        _FakeOption("F205#MILANO#0#0", "MILANO"),
+    ])
+    monkeypatch.setenv("DROPDOWN_CACHE", "1")
+    utils.invalidate_dropdown_cache(reason="test_setup")
+
+    calls = {"n": 0}
+    real = utils._collect_options_fast
+    async def counting(p, s):
+        calls["n"] += 1
+        return await real(p, s)
+    monkeypatch.setattr(utils, "_collect_options_fast", counting)
+
+    r1 = asyncio.run(utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "H501"))
+    r2 = asyncio.run(utils.find_option_by_codice_belfiore(page, "select[name='denomComune']", "F205"))
+    assert r1 == "H501#ROMA#0#0"
+    assert r2 == "F205#MILANO#0#0"
+    # Una sola evaluate: la seconda lookup serve dalla stessa cache
+    assert calls["n"] == 1, f"expected 1 evaluate call, got {calls['n']}"
+
+
+def test_invalidate_dropdown_cache_clears_state():
+    utils._DROPDOWN_CACHE[("province",)] = {"items": [], "by_norm": {}}
+    utils._DROPDOWN_CACHE[("comune", "")] = {"items": [], "by_norm": {}, "by_belfiore": {}}
+    utils.invalidate_dropdown_cache(reason="unit_test")
+    assert utils._DROPDOWN_CACHE == {}

--- a/utils.py
+++ b/utils.py
@@ -773,14 +773,18 @@ async def _get_province_options(page) -> dict:
 async def _get_comune_options(page, provincia_value: Optional[str]) -> dict:
     """Ritorna gli indici dei comuni per ``provincia_value``.
 
-    Cache key = ``("comune", provincia_value)``. Se ``provincia_value`` è ``None``
-    (caller non lo conosce — ramo legacy) usiamo ``""`` come chiave: cache
-    condivisa, comunque utile dentro la stessa request (più chiamate
-    sequenziali sulla stessa pagina post-applica).
+    Cache key = ``("comune", provincia_value)``. **IMPORTANTE**: la cache è
+    abilitata SOLO se ``provincia_value`` è truthy (es. ``"MANTOVA Territorio-MN"``).
+    Se è ``None`` o stringa vuota, NON cachiamo: i comuni cambiano per provincia
+    e una chiave condivisa ``""`` causerebbe cross-province poisoning (regressione
+    osservata 2026-05-15: Mantova 73 comuni → riusati per Savona/Pesaro/...).
+    Il chiamante legacy che non conosce provincia_value paga il singolo evaluate
+    per fetch (comunque rapido, ~3-5ms).
     """
     selector = "select[name='denomComune']"
-    key = ("comune", provincia_value or "")
-    if _dropdown_cache_enabled():
+    cache_ok = bool(provincia_value) and _dropdown_cache_enabled()
+    if cache_ok:
+        key = ("comune", provincia_value)
         cached = _DROPDOWN_CACHE.get(key)
         if cached is not None:
             print(
@@ -789,12 +793,15 @@ async def _get_comune_options(page, provincia_value: Optional[str]) -> dict:
             )
             return cached
         print(f"[CACHE] miss kind=comune provincia='{provincia_value}' fetching live")
+    elif not provincia_value:
+        # Path legacy: nessuna cache possibile (key collision risk)
+        pass
     else:
         print("[CACHE] disabled kind=comune (DROPDOWN_CACHE=0)")
     items = await _collect_options_fast(page, selector)
     idx = _build_comune_indexes(items)
-    if _dropdown_cache_enabled():
-        _DROPDOWN_CACHE[key] = idx
+    if cache_ok:
+        _DROPDOWN_CACHE[("comune", provincia_value)] = idx
         print(f"[CACHE] store kind=comune provincia='{provincia_value}' count={len(items)}")
     return idx
 

--- a/utils.py
+++ b/utils.py
@@ -144,8 +144,15 @@ class PageLogger:
             self.base_dir = None
 
     async def log(self, page: Page, step_name: str) -> None:
-        """Salva l'HTML corrente della pagina su disco (no-op se disabilitato)."""
+        """Salva l'HTML corrente della pagina su disco (no-op se disabilitato).
+
+        Disabilitabile via env ``LOG_PAGES=0`` (default: ``1``). Quando off,
+        ritorna immediatamente senza chiamare ``page.content()`` né scrivere
+        su disco — riduce ~0.5-2s/richiesta su success path.
+        """
         self.step += 1
+        if os.getenv("LOG_PAGES", "1") != "1":
+            return
         if self.base_dir is None:
             return
         try:
@@ -420,7 +427,7 @@ async def login(page: Page):
 
         step = "controllo_sessione"
         print("[LOGIN] Attendo caricamento pagina...")
-        await page.wait_for_load_state("networkidle")
+        await page.wait_for_load_state("domcontentloaded")
         await logger.log(page, "vai_al_servizio")
         print("[LOGIN] Controllo blocco sessione...")
         content = await page.content()
@@ -495,7 +502,7 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
 
         step = "attesa_sister"
         print("[LOGIN] Attendo caricamento portale SISTER...")
-        await page.wait_for_load_state("networkidle", timeout=30000)
+        await page.wait_for_load_state("domcontentloaded", timeout=30000)
         await logger.log(page, "portale_sister")
 
         # Gestione sessioni orfane: ogni CloseSessionsSis chiude UNA sessione
@@ -540,7 +547,7 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
             await page.get_by_role("textbox", name="Utente:").fill(username)
             await page.get_by_role("textbox", name="Password:").fill(password)
             await page.get_by_role("button", name="Accedi").click()
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
             await logger.log(page, f"portale_sister_retry_{attempts_done}")
 
             content = await page.content()
@@ -797,7 +804,7 @@ async def run_visura(
     # STEP 1: Selezione Ufficio Provinciale
     print("[VISURA] Navigando alla pagina di scelta servizio...")
     await page.goto("https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000)
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     print("[VISURA] Pagina caricata")
     await logger.log(page, "scelta_servizio")
 
@@ -858,14 +865,14 @@ async def run_visura(
 
     print("[VISURA] Cliccando Applica...")
     await page.locator("input[type='submit'][value='Applica']").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     print("[VISURA] Applica cliccato, pagina caricata")
     await logger.log(page, "provincia_applicata")
 
     # STEP 2: Ricerca per immobili
     print("[VISURA] Cliccando link Immobile...")
     await page.get_by_role("link", name="Immobile").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     print("[VISURA] Link Immobile cliccato")
     await logger.log(page, "immobile")
 
@@ -928,7 +935,7 @@ async def run_visura(
     if sezione:
         print("[VISURA] Cliccando 'scegli la sezione' per attivare dropdown...")
         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
-        await page.wait_for_load_state("networkidle", timeout=30000)
+        await page.wait_for_load_state("domcontentloaded", timeout=30000)
         print("[VISURA] Button sezione cliccato, dropdown attivato")
 
         # Prima estrai tutte le opzioni disponibili per debug
@@ -988,7 +995,7 @@ async def run_visura(
     # Clicca Ricerca
     print("[VISURA] Cliccando Ricerca...")
     await page.locator("input[name='scelta'][value='Ricerca']").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     print("[VISURA] Ricerca cliccata")
     await logger.log(page, "ricerca")
 
@@ -999,7 +1006,7 @@ async def run_visura(
         if await conferma_button.count() > 0:
             print("[VISURA] Rilevata richiesta conferma assenza subalterno...")
             await conferma_button.click()
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
             print("[VISURA] Conferma assenza subalterno cliccata")
             await logger.log(page, "conferma_subalterno")
     except Exception as e:
@@ -1116,7 +1123,7 @@ async def run_visura(
 
         if intestati_button:
             await intestati_button.click()
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
             print("[VISURA] Intestati cliccato")
             await logger.log(page, "intestati")
 
@@ -1267,7 +1274,7 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
         await page.goto(
             "https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000
         )
-        await page.wait_for_load_state("networkidle", timeout=30000)
+        await page.wait_for_load_state("domcontentloaded", timeout=30000)
         print("[SEZIONI] Pagina caricata")
         await logger.log(page, "scelta_servizio")
 
@@ -1300,13 +1307,13 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
                 print("[SEZIONI] Cliccando Applica...")
                 await page.locator("input[type='submit'][value='Applica']").click()
-                await page.wait_for_load_state("networkidle", timeout=30000)
+                await page.wait_for_load_state("domcontentloaded", timeout=30000)
                 print("[SEZIONI] Applica cliccato, pagina caricata")
 
                 # Vai alla ricerca immobili (stesso modo di run_visura)
                 print("[SEZIONI] Cliccando link Immobile...")
                 await page.get_by_role("link", name="Immobile").click()
-                await page.wait_for_load_state("networkidle", timeout=30000)
+                await page.wait_for_load_state("domcontentloaded", timeout=30000)
                 print("[SEZIONI] Link Immobile cliccato")
 
                 # Seleziona tipo catasto (stesso modo di run_visura)
@@ -1344,7 +1351,7 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
                         # Attiva selezione sezione (ESATTO come in run_visura)
                         print("[SEZIONI] Cliccando 'scegli la sezione' per attivare dropdown...")
                         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
-                        await page.wait_for_load_state("networkidle", timeout=30000)
+                        await page.wait_for_load_state("domcontentloaded", timeout=30000)
                         print("[SEZIONI] Button sezione cliccato, dropdown attivato")
 
                         # Estrai le sezioni per questo comune (stesso modo di run_visura)
@@ -1428,7 +1435,7 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
                 await page.goto(
                     "https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000
                 )
-                await page.wait_for_load_state("networkidle", timeout=30000)
+                await page.wait_for_load_state("domcontentloaded", timeout=30000)
                 print("[SEZIONI] Tornato alla pagina principale")
 
             except Exception as e:
@@ -1482,7 +1489,7 @@ async def run_visura_immobile(
     # STEP 1: Selezione Ufficio Provinciale
     print("[VISURA_IMMOBILE] Navigando alla pagina di scelta servizio...")
     await page.goto("https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000)
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     print("[VISURA_IMMOBILE] Pagina caricata")
     await logger.log(page, "scelta_servizio")
 
@@ -1502,13 +1509,13 @@ async def run_visura_immobile(
     await page.locator("select[name='listacom']").select_option(provincia_value)
     print("[VISURA_IMMOBILE] Cliccando Applica...")
     await page.locator("input[type='submit'][value='Applica']").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     await logger.log(page, "provincia_applicata")
 
     # STEP 2: Ricerca per immobili
     print("[VISURA_IMMOBILE] Cliccando link Immobile...")
     await page.get_by_role("link", name="Immobile").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     await logger.log(page, "immobile")
 
     # STEP 2.1: Seleziona tipo catasto FABBRICATI (F)
@@ -1540,7 +1547,7 @@ async def run_visura_immobile(
     if sezione:
         print("[VISURA_IMMOBILE] Cliccando 'scegli la sezione' per attivare dropdown...")
         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
-        await page.wait_for_load_state("networkidle", timeout=30000)
+        await page.wait_for_load_state("domcontentloaded", timeout=30000)
 
         # Controlla se ci sono sezioni disponibili
         options = await page.locator("select[name='sezione'] option").all()
@@ -1584,7 +1591,7 @@ async def run_visura_immobile(
     # Clicca Ricerca
     print("[VISURA_IMMOBILE] Cliccando Ricerca...")
     await page.locator("input[name='scelta'][value='Ricerca']").click()
-    await page.wait_for_load_state("networkidle", timeout=30000)
+    await page.wait_for_load_state("domcontentloaded", timeout=30000)
     await logger.log(page, "ricerca")
 
     # STEP 3: Gestisci conferma assenza subalterno (se necessario)
@@ -1593,7 +1600,7 @@ async def run_visura_immobile(
         if await conferma_button.count() > 0:
             print("[VISURA_IMMOBILE] Rilevata richiesta conferma assenza subalterno...")
             await conferma_button.click()
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
             await logger.log(page, "conferma_subalterno")
     except Exception as e:
         print(f"[VISURA_IMMOBILE] Errore o non necessaria conferma subalterno: {e}")
@@ -1643,7 +1650,7 @@ async def run_visura_immobile(
 
         if intestati_button:
             await intestati_button.click()
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
             print("[VISURA_IMMOBILE] Intestati cliccato")
             await logger.log(page, "intestati")
 

--- a/utils.py
+++ b/utils.py
@@ -308,8 +308,7 @@ async def login(page: Page):
             raise ValueError("SISTER_USERNAME and SISTER_PASSWORD environment variables must be set")
     else:
         raise ValueError(
-            f"SPID_PROVIDER non supportato: '{spid_provider}'. "
-            "Valori validi: 'sielte', 'poste', 'sister'"
+            f"SPID_PROVIDER non supportato: '{spid_provider}'. " "Valori validi: 'sielte', 'poste', 'sister'"
         )
 
     logger = PageLogger("login")
@@ -433,12 +432,41 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
         await page.wait_for_load_state("networkidle", timeout=30000)
         await logger.log(page, "portale_sister")
 
-        # Verifica blocco sessione (stessa logica del flusso SPID)
-        content = await page.content()
-        url = page.url
-        if "Utente gia' in sessione" in content or "error_locked.jsp" in url:
-            print("[LOGIN][ERRORE] Utente già in sessione su un'altra postazione!")
-            raise Exception("Utente già in sessione su un'altra postazione")
+        # Gestione sessioni orfane: ogni CloseSessionsSis chiude UNA sessione
+        # stale. Dopo molti riavvii possono accumularsi più sessioni, perciò
+        # proviamo fino a 10 volte prima di alzare l'eccezione.
+        for attempt in range(1, 11):
+            content = await page.content()
+            url = page.url
+            if "Utente gia' in sessione" not in content and "error_locked.jsp" not in url:
+                break
+
+            print(f"[LOGIN] Sessione orfana rilevata (tentativo {attempt}/10) — chiudo e riprovo...")
+            step = f"close_session_{attempt}"
+            await page.goto(
+                "https://sister3.agenziaentrate.gov.it/Servizi/CloseSessionsSis",
+                timeout=30000,
+            )
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
+            await logger.log(page, f"close_session_{attempt}")
+
+            step = f"sister_tab_retry_{attempt}"
+            await page.goto(
+                "https://iampe.agenziaentrate.gov.it/sam/UI/Login?realm=/agenziaentrate",
+                timeout=30000,
+            )
+            await page.wait_for_load_state("domcontentloaded", timeout=30000)
+            await page.get_by_role("tab", name="Sister").click()
+            await page.get_by_role("textbox", name="Utente:").fill(username)
+            await page.get_by_role("textbox", name="Password:").fill(password)
+            await page.get_by_role("button", name="Accedi").click()
+            await page.wait_for_load_state("networkidle", timeout=30000)
+            await logger.log(page, f"portale_sister_retry_{attempt}")
+        else:
+            print("[LOGIN][ERRORE] Troppe sessioni orfane, impossibile liberare la sessione.")
+            raise Exception("Utente già in sessione su un'altra postazione (max 10 tentativi raggiunto)")
+
+        print("[LOGIN] Login SISTER completato.")
 
     except Exception:
         await logger.log(page, f"ERRORE_sister_{step}")

--- a/utils.py
+++ b/utils.py
@@ -640,6 +640,165 @@ def _normalize_for_match(value: str) -> str:
     return re.sub(r"\s+", " ", lowered).strip()
 
 
+# =============================================================================
+# Dropdown options: estrazione fast (single page.evaluate) + cache process-wide
+# =============================================================================
+#
+# Motivazione perf:
+#   Il pattern originale ``page.locator(sel).all()`` + N×(``get_attribute`` +
+#   ``inner_text``) costa 2N round-trip CDP. Con ~110 province o ~300 comuni
+#   sono 600-1800ms di IPC puro per ogni richiesta. ``page.evaluate`` esegue
+#   un singolo round-trip e ritorna l'array completo in JSON (≪100ms).
+#
+# Cache:
+#   - ``_DROPDOWN_CACHE[("province",)]`` → {"items": [(value, text)], "by_norm": {…}}
+#     Province: stabili nel tempo (cambiano <1/anno). Una volta caricate, riusate
+#     per tutta la vita del processo.
+#   - ``_DROPDOWN_CACHE[("comune", provincia_value)]`` →
+#     {"items": [(value, text)], "by_belfiore": {CB: value}, "by_norm": {norm: value}}
+#     Comuni per provincia: anch'essi stabili (catastalmente). Cache per-provincia.
+#
+# Diagnostica:
+#   - ``[OPTS]`` log ogni estrazione live con count + elapsed.
+#   - ``[CACHE hit|miss|STALE|disabled]`` ogni accesso alla cache.
+#   - Kill switch: ``DROPDOWN_CACHE=0`` disabilita interamente la cache (fallback
+#     a estrazione live ogni volta, ma comunque con ``_collect_options_fast``).
+#   - In caso di failure su ``select_option`` chiamare ``invalidate_dropdown_cache``
+#     per forzare un refetch alla richiesta successiva.
+
+_DROPDOWN_CACHE: dict = {}
+
+
+def _dropdown_cache_enabled() -> bool:
+    return os.getenv("DROPDOWN_CACHE", "1") == "1"
+
+
+def invalidate_dropdown_cache(reason: str = "") -> None:
+    """Svuota la cache delle dropdown SISTER.
+
+    Chiamare quando un ``select_option`` fallisce con un valore preso dalla
+    cache (cache stale), o su restart browser/recovery sessione. Stampa il
+    motivo per diagnostica (grep ``[CACHE] invalidate``).
+    """
+    n = len(_DROPDOWN_CACHE)
+    _DROPDOWN_CACHE.clear()
+    print(f"[CACHE] invalidate cleared={n} reason={reason or 'unspecified'}")
+
+
+async def _collect_options_fast(page, selector: str) -> list:
+    """Estrae tutte le ``<option>`` di ``selector`` in un solo round-trip CDP.
+
+    Ritorna lista di tuple ``(value, text)``. Sostituisce il pattern
+    ``locator(...).all()`` + N×``get_attribute``/``inner_text`` (2N round-trip).
+    Lascia trasparire le eccezioni Playwright al chiamante per non mascherare
+    bug strutturali (selector errato, pagina chiusa, ecc.).
+    """
+    t0 = time.time()
+    raw = await page.evaluate(
+        """sel => Array.from(document.querySelectorAll(sel + ' option'))
+                    .map(o => [o.value || '', (o.textContent || '').trim()])""",
+        selector,
+    )
+    # raw è una lista di liste [value, text]; normalizza a tuple di str
+    items = [(str(v or ""), str(t or "")) for v, t in raw]
+    elapsed_ms = (time.time() - t0) * 1000
+    print(f"[OPTS] selector='{selector}' count={len(items)} source=evaluate elapsed={elapsed_ms:.0f}ms")
+    return items
+
+
+def _build_comune_indexes(items: list) -> dict:
+    """Costruisce indici lookup per i comuni: by codice belfiore e by nome normalizzato.
+
+    ``items`` è la lista (value, text) ritornata da ``_collect_options_fast``.
+    Le option SISTER hanno ``value`` nella forma ``CB#NOME#0#0`` (es. ``H501#ROMA#0#0``).
+    """
+    by_belfiore: dict = {}
+    by_norm: dict = {}
+    for value, text in items:
+        if not value:
+            continue
+        # codice belfiore: prefisso prima del primo '#'
+        prefix = value.split("#", 1)[0].upper().strip()
+        if prefix and prefix not in by_belfiore:
+            by_belfiore[prefix] = value
+        if text:
+            norm = _normalize_for_match(text)
+            if norm and norm not in by_norm:
+                by_norm[norm] = value
+    return {"items": items, "by_belfiore": by_belfiore, "by_norm": by_norm}
+
+
+def _build_province_indexes(items: list) -> dict:
+    """Costruisce indici lookup per le province: solo by nome normalizzato."""
+    by_norm: dict = {}
+    for value, text in items:
+        if not value or not text:
+            continue
+        norm = _normalize_for_match(text)
+        if norm and norm not in by_norm:
+            by_norm[norm] = value
+    return {"items": items, "by_norm": by_norm}
+
+
+def _format_options_for_debug(items: list) -> list:
+    """Ritorna lista 'text (value)' per le print di diagnostica 'disponibili'.
+
+    ``items`` è il valore ritornato da ``_collect_options_fast``.
+    Filtra entry con value o text vuoto. Usato per costruire il messaggio di
+    errore quando una option non viene trovata: l'output coincide con il
+    formato originale (`f"{text} ({value})"`).
+    """
+    return [f"{t} ({v})" for v, t in items if v and t]
+
+
+async def _get_province_options(page) -> dict:
+    """Ritorna gli indici delle province SISTER, cache process-wide se abilitata."""
+    selector = "select[name='listacom']"
+    if _dropdown_cache_enabled():
+        cached = _DROPDOWN_CACHE.get(("province",))
+        if cached is not None:
+            print(f"[CACHE] hit kind=province count={len(cached['items'])}")
+            return cached
+        print("[CACHE] miss kind=province fetching live")
+    else:
+        print("[CACHE] disabled kind=province (DROPDOWN_CACHE=0)")
+    items = await _collect_options_fast(page, selector)
+    idx = _build_province_indexes(items)
+    if _dropdown_cache_enabled():
+        _DROPDOWN_CACHE[("province",)] = idx
+        print(f"[CACHE] store kind=province count={len(items)}")
+    return idx
+
+
+async def _get_comune_options(page, provincia_value: Optional[str]) -> dict:
+    """Ritorna gli indici dei comuni per ``provincia_value``.
+
+    Cache key = ``("comune", provincia_value)``. Se ``provincia_value`` è ``None``
+    (caller non lo conosce — ramo legacy) usiamo ``""`` come chiave: cache
+    condivisa, comunque utile dentro la stessa request (più chiamate
+    sequenziali sulla stessa pagina post-applica).
+    """
+    selector = "select[name='denomComune']"
+    key = ("comune", provincia_value or "")
+    if _dropdown_cache_enabled():
+        cached = _DROPDOWN_CACHE.get(key)
+        if cached is not None:
+            print(
+                f"[CACHE] hit kind=comune provincia='{provincia_value}' "
+                f"count={len(cached['items'])}"
+            )
+            return cached
+        print(f"[CACHE] miss kind=comune provincia='{provincia_value}' fetching live")
+    else:
+        print("[CACHE] disabled kind=comune (DROPDOWN_CACHE=0)")
+    items = await _collect_options_fast(page, selector)
+    idx = _build_comune_indexes(items)
+    if _dropdown_cache_enabled():
+        _DROPDOWN_CACHE[key] = idx
+        print(f"[CACHE] store kind=comune provincia='{provincia_value}' count={len(items)}")
+    return idx
+
+
 async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: str) -> Optional[str]:
     """Trova un'option SISTER il cui ``value`` inizia con ``{codice_belfiore}#``.
 
@@ -653,6 +812,10 @@ async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: s
 
     Ritorna il ``value`` dell'option oppure ``None`` se nessuna option
     nel ``select`` ha quel prefisso.
+
+    Implementazione (perf): usa ``_collect_options_fast`` (singolo evaluate)
+    con cache per-provincia. Se il selector non è quello dei comuni SISTER
+    fa fallback a un evaluate diretto senza cache.
     """
     if not codice_belfiore:
         return None
@@ -660,12 +823,24 @@ async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: s
     if not cb:
         return None
     prefix = f"{cb}#"
-    options = await page.locator(f"{selector} option").all()
-    print(f"[MATCH_BELFIORE] Cerco codice belfiore '{cb}' tra {len(options)} option")
-    for option in options:
-        value = await option.get_attribute("value")
+    # Path veloce con cache per il selector standard dei comuni
+    if selector == "select[name='denomComune']":
+        idx = await _get_comune_options(page, provincia_value=None)
+        value = idx["by_belfiore"].get(cb)
+        if value:
+            print(f"[MATCH_BELFIORE] hit cache cb='{cb}' -> '{value}'")
+            return value
+        # No-hit: log e ritorna None (caller fa fallback su match by name)
+        print(
+            f"[MATCH_BELFIORE] miss cb='{cb}' tra {len(idx['items'])} option "
+            f"(comuni provincia corrente)"
+        )
+        return None
+    # Path generico (no cache): un solo evaluate + scan
+    items = await _collect_options_fast(page, selector)
+    print(f"[MATCH_BELFIORE] Cerco codice belfiore '{cb}' tra {len(items)} option (no-cache)")
+    for value, text in items:
         if value and value.upper().startswith(prefix):
-            text = await option.inner_text()
             print(f"[MATCH_BELFIORE] Match: '{text}' -> '{value}'")
             return value
     print(f"[MATCH_BELFIORE] Nessuna option con prefisso '{prefix}'")
@@ -688,19 +863,37 @@ async def find_best_option_match(page, selector, search_text):
     → contains → match dell'alias catastale. Restituisce il ``value``
     dell'option scelta, oppure ``None`` se nessuna opzione è plausibile.
     """
-    options = await page.locator(f"{selector} option").all()
+    # Estrazione fast (single evaluate) + cache process-wide per i selector standard
+    if selector == "select[name='listacom']":
+        idx = await _get_province_options(page)
+        items = idx["items"]
+        # Tentativo lookup O(1) sulla cache by normalized name
+        search_norm_pre = _normalize_for_match(search_text)
+        if search_norm_pre and search_norm_pre in idx["by_norm"]:
+            v = idx["by_norm"][search_norm_pre]
+            print(f"[MATCH] CACHE hit provincia '{search_text}' -> '{v}'")
+            return v
+    elif selector == "select[name='denomComune']":
+        idx = await _get_comune_options(page, provincia_value=None)
+        items = idx["items"]
+        search_norm_pre = _normalize_for_match(search_text)
+        if search_norm_pre and search_norm_pre in idx["by_norm"]:
+            v = idx["by_norm"][search_norm_pre]
+            print(f"[MATCH] CACHE hit comune '{search_text}' -> '{v}'")
+            return v
+    else:
+        # Selector non standard (es. select[name='sezione']) — solo evaluate, no cache
+        items = await _collect_options_fast(page, selector)
+
     best_match = None
     best_score = 0
 
-    print(f"[MATCH] Cerco '{search_text}' tra {len(options)} opzioni")
+    print(f"[MATCH] Cerco '{search_text}' tra {len(items)} opzioni (post-fast)")
 
     search_norm = _normalize_for_match(search_text)
     search_alias = _CATASTAL_PROVINCE_ALIASES.get(search_norm)
 
-    for option in options:
-        value = await option.get_attribute("value")
-        text = await option.inner_text()
-
+    for value, text in items:
         if not value or not text:
             continue
 
@@ -832,14 +1025,9 @@ async def run_visura(
     # Trova e seleziona la provincia corretta
     print(f"[VISURA] Cercando provincia: {provincia}")
 
-    # Prima estrai tutte le province disponibili per debug
-    provincia_options = await page.locator("select[name='listacom'] option").all()
-    available_provinces = []
-    for option in provincia_options:
-        value = await option.get_attribute("value")
-        text = await option.inner_text()
-        if value and text:
-            available_provinces.append(f"{text} ({value})")
+    # Prima estrai tutte le province disponibili per debug (single evaluate via helper)
+    _prov_items = await _collect_options_fast(page, "select[name='listacom']")
+    available_provinces = _format_options_for_debug(_prov_items)
 
     # Se non ci sono province disponibili, probabilmente la sessione è scaduta
     if len(available_provinces) == 0:
@@ -888,14 +1076,9 @@ async def run_visura(
     # Trova e seleziona il comune corretto
     print(f"[VISURA] Cercando comune: {comune}")
 
-    # Prima estrai tutti i comuni disponibili per debug
-    comune_options = await page.locator("select[name='denomComune'] option").all()
-    available_comuni = []
-    for option in comune_options:
-        value = await option.get_attribute("value")
-        text = await option.inner_text()
-        if value and text:
-            available_comuni.append(f"{text} ({value})")
+    # Prima estrai tutti i comuni disponibili per debug (single evaluate via helper)
+    _comune_items = await _collect_options_fast(page, "select[name='denomComune']")
+    available_comuni = _format_options_for_debug(_comune_items)
 
     print(
         f"[VISURA] Comuni disponibili: {', '.join(available_comuni[:10])}{'...' if len(available_comuni) > 10 else ''}"
@@ -938,14 +1121,9 @@ async def run_visura(
         await page.wait_for_load_state("domcontentloaded", timeout=30000)
         print("[VISURA] Button sezione cliccato, dropdown attivato")
 
-        # Prima estrai tutte le opzioni disponibili per debug
-        options = await page.locator("select[name='sezione'] option").all()
-        available_sections = []
-        for option in options:
-            value = await option.get_attribute("value")
-            text = await option.inner_text()
-            if value and text:
-                available_sections.append(f"{text} ({value})")
+        # Prima estrai tutte le opzioni disponibili per debug (single evaluate via helper)
+        _sez_items = await _collect_options_fast(page, "select[name='sezione']")
+        available_sections = _format_options_for_debug(_sez_items)
 
         print(f"[VISURA] Sezioni disponibili: {', '.join(available_sections)}")
 
@@ -1280,12 +1458,10 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
         # Estrai tutte le province
         print("[SEZIONI] Estraendo lista province...")
-        provincia_options = await page.locator("select[name='listacom'] option").all()
+        _prov_items_iv = await _collect_options_fast(page, "select[name='listacom']")
         province_list = []
 
-        for option in provincia_options:
-            value = await option.get_attribute("value")
-            text = await option.inner_text()
+        for value, text in _prov_items_iv:
             if value and text and value.strip() and text.strip():
                 # Salta "NAZIONALE" che sembra problematico
                 if "NAZIONALE" not in text.upper():
@@ -1326,12 +1502,10 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
                 # Estrai tutti i comuni per questa provincia
                 print("[SEZIONI] Estraendo lista comuni...")
-                comune_options = await page.locator("select[name='denomComune'] option").all()
+                _comune_items_iv = await _collect_options_fast(page, "select[name='denomComune']")
                 comuni_list = []
 
-                for option in comune_options:
-                    value = await option.get_attribute("value")
-                    text = await option.inner_text()
+                for value, text in _comune_items_iv:
                     if value and text and value.strip() and text.strip():
                         comuni_list.append({"value": value.strip(), "text": text.strip()})
 
@@ -1360,12 +1534,10 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
                         try:
                             # Prima verifica se ci sono sezioni disponibili
-                            sezione_options = await page.locator("select[name='sezione'] option").all()
+                            _sez_items_iv = await _collect_options_fast(page, "select[name='sezione']")
                             available_sections = []
 
-                            for option in sezione_options:
-                                value = await option.get_attribute("value")
-                                text = await option.inner_text()
+                            for value, text in _sez_items_iv:
                                 if value and text and value.strip() and text.strip():
                                     available_sections.append({"value": value.strip(), "text": text.strip()})
 
@@ -1549,14 +1721,9 @@ async def run_visura_immobile(
         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
         await page.wait_for_load_state("domcontentloaded", timeout=30000)
 
-        # Controlla se ci sono sezioni disponibili
-        options = await page.locator("select[name='sezione'] option").all()
-        available_sections = []
-        for option in options:
-            value = await option.get_attribute("value")
-            text = await option.inner_text()
-            if value and text:
-                available_sections.append(f"{text} ({value})")
+        # Controlla se ci sono sezioni disponibili (single evaluate via helper)
+        _sez_items_im = await _collect_options_fast(page, "select[name='sezione']")
+        available_sections = _format_options_for_debug(_sez_items_im)
 
         if not available_sections:
             print(f"[VISURA_IMMOBILE] Nessuna sezione disponibile per il comune '{comune}', saltando selezione sezione")

--- a/utils.py
+++ b/utils.py
@@ -564,7 +564,11 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
 # ``_normalize_for_match``. Estendere qui se emergono nuovi casi.
 _CATASTAL_PROVINCE_ALIASES = {
     "verbano cusio ossola": "verbania",
-    "monza e della brianza": "monza brianza",
+    # ISTAT "Monza e della Brianza" (istituita 2009): SISTER non la espone come
+    # ufficio provinciale catastale separato — i comuni della Brianza restano
+    # catastalmente sotto "MILANO Territorio" (confermato bulk-test
+    # 2026-05-15, p.es. Misinto, Lissone). Vedi anche _UNSUPPORTED_PROVINCES.
+    "monza e della brianza": "milano",
     "forli cesena": "forli",
     # ISTAT usa "Reggio nell'Emilia", SISTER espone solo "REGGIO EMILIA"
     # (confermato sperimentalmente, vedi AUDIT_REPORT_2026-05-15.md)
@@ -575,6 +579,33 @@ _CATASTAL_PROVINCE_ALIASES = {
     "sud sardegna": "cagliari",
     # ISTAT usa "Pesaro e Urbino", SISTER espone solo "PESARO Territorio".
     "pesaro e urbino": "pesaro",
+    # ISTAT "Valle d'Aosta/Vallée d'Aoste" (forma bilingue): SISTER ha
+    # solo "AOSTA Territorio". Scoperto nel bulk-test 97 particelle del
+    # 2026-05-15 (Pont-Saint-Martin, Arvier, Champorcher).
+    "valle d aosta vallee d aoste": "aosta",
+    "valle d aosta": "aosta",
+    "vallee d aoste": "aosta",
+}
+
+
+# Province che SISTER NON espone perché il catasto è gestito da un sistema
+# regionale separato (Sistema Tavolare austriaco) o perché l'ufficio non è
+# stato mai disaggregato. Le richieste per queste province falliscono in modo
+# esplicito con un messaggio attionable, invece di esaurire il timeout sul
+# matching della dropdown.
+#
+# Chiavi normalizzate con ``_normalize_for_match``. Estendere se emergono
+# nuovi casi confermati sperimentalmente.
+_UNSUPPORTED_PROVINCES_SISTER = {
+    # Provincia Autonoma di Trento — Catasto Tavolare (Libro Fondiario)
+    "trento": "Provincia Autonoma di Trento: catasto gestito dal Sistema "
+              "Tavolare (Libro Fondiario), non disponibile su SISTER.",
+    # Provincia Autonoma di Bolzano / Südtirol — Catasto Tavolare
+    "bolzano": "Provincia Autonoma di Bolzano: catasto gestito dal Sistema "
+               "Tavolare (Libro Fondiario), non disponibile su SISTER.",
+    "bolzano bozen": "Provincia Autonoma di Bolzano: catasto gestito dal "
+                     "Sistema Tavolare (Libro Fondiario), non disponibile "
+                     "su SISTER.",
 }
 
 
@@ -752,6 +783,13 @@ async def run_visura(
     print(
         f"[VISURA] Inizio visura: provincia={provincia}, comune={comune}{sezione_info}, foglio={foglio}, particella={particella}{subalterno_info}, tipo_catasto={tipo_catasto}"
     )
+
+    # Fail-fast su province non supportate (Trento/Bolzano: Catasto Tavolare).
+    # Evita di navigare SISTER inutilmente e restituisce un errore actionable.
+    provincia_norm = _normalize_for_match(provincia)
+    unsupported_reason = _UNSUPPORTED_PROVINCES_SISTER.get(provincia_norm)
+    if unsupported_reason:
+        raise Exception(unsupported_reason)
 
     # Non creare una nuova pagina, usa quella esistente
     print("[VISURA] Utilizzando pagina di autenticazione esistente")
@@ -1434,6 +1472,12 @@ async def run_visura_immobile(
 
     if not subalterno:
         raise ValueError("Il subalterno è obbligatorio per le visure per immobile specifico")
+
+    # Fail-fast su province non supportate (Trento/Bolzano: Catasto Tavolare).
+    provincia_norm = _normalize_for_match(provincia)
+    unsupported_reason = _UNSUPPORTED_PROVINCES_SISTER.get(provincia_norm)
+    if unsupported_reason:
+        raise Exception(unsupported_reason)
 
     # STEP 1: Selezione Ufficio Provinciale
     print("[VISURA_IMMOBILE] Navigando alla pagina di scelta servizio...")

--- a/utils.py
+++ b/utils.py
@@ -669,6 +669,28 @@ def _normalize_for_match(value: str) -> str:
 _DROPDOWN_CACHE: dict = {}
 
 
+async def _wait_for_ready(page, selector: str, timeout_ms: int = 30000, label: str = "") -> None:
+    """Attende che ``selector`` sia attached/visible nel DOM.
+
+    Sostituisce il pattern ``wait_for_load_state("domcontentloaded")`` quando
+    il vero "ready" del passo \u00e8 la presenza di un elemento target specifico
+    (es. la prossima ``<select>`` del form, il link "Immobile", la tabella
+    risultati). Ritorna appena il selector \u00e8 visibile (tipicamente molto
+    prima del DOMContentLoaded completo, perch\u00e9 SISTER carica asset extra
+    dopo che il form \u00e8 gi\u00e0 interattivo).
+
+    Diagnostica: stampa ``[WAIT] label='...' selector='...' elapsed=Yms`` per
+    grep delle latenze. In caso di timeout l'eccezione Playwright fa propagare
+    il contesto al chiamante.
+    """
+    t0 = time.time()
+    try:
+        await page.wait_for_selector(selector, state="visible", timeout=timeout_ms)
+    finally:
+        elapsed_ms = (time.time() - t0) * 1000
+        print(f"[WAIT] label='{label}' selector='{selector}' elapsed={elapsed_ms:.0f}ms")
+
+
 def _dropdown_cache_enabled() -> bool:
     return os.getenv("DROPDOWN_CACHE", "1") == "1"
 
@@ -806,7 +828,12 @@ async def _get_comune_options(page, provincia_value: Optional[str]) -> dict:
     return idx
 
 
-async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: str) -> Optional[str]:
+async def find_option_by_codice_belfiore(
+    page,
+    selector: str,
+    codice_belfiore: str,
+    provincia_value: Optional[str] = None,
+) -> Optional[str]:
     """Trova un'option SISTER il cui ``value`` inizia con ``{codice_belfiore}#``.
 
     Le option di ``select[name='denomComune']`` in SISTER hanno valore nella
@@ -821,8 +848,11 @@ async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: s
     nel ``select`` ha quel prefisso.
 
     Implementazione (perf): usa ``_collect_options_fast`` (singolo evaluate)
-    con cache per-provincia. Se il selector non è quello dei comuni SISTER
-    fa fallback a un evaluate diretto senza cache.
+    con cache per-provincia se ``provincia_value`` è valorizzato (passare il
+    value della provincia già selezionata permette di cachare i comuni della
+    provincia corrente in modo sicuro, senza cross-province poisoning). Se
+    il selector non è quello dei comuni SISTER fa fallback a un evaluate
+    diretto senza cache.
     """
     if not codice_belfiore:
         return None
@@ -832,7 +862,7 @@ async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: s
     prefix = f"{cb}#"
     # Path veloce con cache per il selector standard dei comuni
     if selector == "select[name='denomComune']":
-        idx = await _get_comune_options(page, provincia_value=None)
+        idx = await _get_comune_options(page, provincia_value=provincia_value)
         value = idx["by_belfiore"].get(cb)
         if value:
             print(f"[MATCH_BELFIORE] hit cache cb='{cb}' -> '{value}'")
@@ -854,7 +884,7 @@ async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: s
     return None
 
 
-async def find_best_option_match(page, selector, search_text):
+async def find_best_option_match(page, selector, search_text, provincia_value: Optional[str] = None):
     """Trova l'opzione che meglio corrisponde al testo cercato.
 
     Il matching è tollerante a:
@@ -869,6 +899,10 @@ async def find_best_option_match(page, selector, search_text):
     L'ordine di priorità del matching è: exact value → exact text → starts-with
     → contains → match dell'alias catastale. Restituisce il ``value``
     dell'option scelta, oppure ``None`` se nessuna opzione è plausibile.
+
+    ``provincia_value`` (opzionale) è usato solo quando ``selector`` è
+    ``select[name='denomComune']``: passarlo abilita la cache comune
+    scope-per-provincia in modo sicuro (evita cross-province poisoning).
     """
     # Estrazione fast (single evaluate) + cache process-wide per i selector standard
     if selector == "select[name='listacom']":
@@ -881,7 +915,7 @@ async def find_best_option_match(page, selector, search_text):
             print(f"[MATCH] CACHE hit provincia '{search_text}' -> '{v}'")
             return v
     elif selector == "select[name='denomComune']":
-        idx = await _get_comune_options(page, provincia_value=None)
+        idx = await _get_comune_options(page, provincia_value=provincia_value)
         items = idx["items"]
         search_norm_pre = _normalize_for_match(search_text)
         if search_norm_pre and search_norm_pre in idx["by_norm"]:
@@ -1004,7 +1038,7 @@ async def run_visura(
     # STEP 1: Selezione Ufficio Provinciale
     print("[VISURA] Navigando alla pagina di scelta servizio...")
     await page.goto("https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000)
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(page, "select[name='listacom']", label="visura_scelta_servizio")
     print("[VISURA] Pagina caricata")
     await logger.log(page, "scelta_servizio")
 
@@ -1060,14 +1094,18 @@ async def run_visura(
 
     print("[VISURA] Cliccando Applica...")
     await page.locator("input[type='submit'][value='Applica']").click()
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(
+        page,
+        "a:has-text('Immobile'), [role='link']:has-text('Immobile')",
+        label="visura_post_applica",
+    )
     print("[VISURA] Applica cliccato, pagina caricata")
     await logger.log(page, "provincia_applicata")
 
     # STEP 2: Ricerca per immobili
     print("[VISURA] Cliccando link Immobile...")
     await page.get_by_role("link", name="Immobile").click()
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(page, "select[name='denomComune']", label="visura_post_immobile")
     print("[VISURA] Link Immobile cliccato")
     await logger.log(page, "immobile")
 
@@ -1098,7 +1136,8 @@ async def run_visura(
     comune_value = None
     if codice_belfiore:
         comune_value = await find_option_by_codice_belfiore(
-            page, "select[name='denomComune']", codice_belfiore
+            page, "select[name='denomComune']", codice_belfiore,
+            provincia_value=provincia_value,
         )
         if not comune_value:
             print(
@@ -1107,7 +1146,10 @@ async def run_visura(
             )
 
     if not comune_value:
-        comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
+        comune_value = await find_best_option_match(
+            page, "select[name='denomComune']", comune,
+            provincia_value=provincia_value,
+        )
 
     if not comune_value:
         raise Exception(
@@ -1125,7 +1167,7 @@ async def run_visura(
     if sezione:
         print("[VISURA] Cliccando 'scegli la sezione' per attivare dropdown...")
         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
-        await page.wait_for_load_state("domcontentloaded", timeout=30000)
+        await _wait_for_ready(page, "select[name='sezione']", label="visura_sezione_open")
         print("[VISURA] Button sezione cliccato, dropdown attivato")
 
         # Prima estrai tutte le opzioni disponibili per debug (single evaluate via helper)
@@ -1668,7 +1710,7 @@ async def run_visura_immobile(
     # STEP 1: Selezione Ufficio Provinciale
     print("[VISURA_IMMOBILE] Navigando alla pagina di scelta servizio...")
     await page.goto("https://sister3.agenziaentrate.gov.it/Visure/SceltaServizio.do?tipo=/T/TM/VCVC_", timeout=60000)
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(page, "select[name='listacom']", label="immobile_scelta_servizio")
     print("[VISURA_IMMOBILE] Pagina caricata")
     await logger.log(page, "scelta_servizio")
 
@@ -1688,13 +1730,17 @@ async def run_visura_immobile(
     await page.locator("select[name='listacom']").select_option(provincia_value)
     print("[VISURA_IMMOBILE] Cliccando Applica...")
     await page.locator("input[type='submit'][value='Applica']").click()
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(
+        page,
+        "a:has-text('Immobile'), [role='link']:has-text('Immobile')",
+        label="immobile_post_applica",
+    )
     await logger.log(page, "provincia_applicata")
 
     # STEP 2: Ricerca per immobili
     print("[VISURA_IMMOBILE] Cliccando link Immobile...")
     await page.get_by_role("link", name="Immobile").click()
-    await page.wait_for_load_state("domcontentloaded", timeout=30000)
+    await _wait_for_ready(page, "select[name='denomComune']", label="immobile_post_immobile")
     await logger.log(page, "immobile")
 
     # STEP 2.1: Seleziona tipo catasto FABBRICATI (F)
@@ -1706,7 +1752,8 @@ async def run_visura_immobile(
     comune_value = None
     if codice_belfiore:
         comune_value = await find_option_by_codice_belfiore(
-            page, "select[name='denomComune']", codice_belfiore
+            page, "select[name='denomComune']", codice_belfiore,
+            provincia_value=provincia_value,
         )
         if not comune_value:
             print(
@@ -1714,7 +1761,10 @@ async def run_visura_immobile(
                 f"fallback al match per nome '{comune}'"
             )
     if not comune_value:
-        comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
+        comune_value = await find_best_option_match(
+            page, "select[name='denomComune']", comune,
+            provincia_value=provincia_value,
+        )
 
     if not comune_value:
         raise Exception(f"Comune '{comune}' non trovato nelle opzioni disponibili")
@@ -1726,7 +1776,7 @@ async def run_visura_immobile(
     if sezione:
         print("[VISURA_IMMOBILE] Cliccando 'scegli la sezione' per attivare dropdown...")
         await page.locator("input[name='selSezione'][value='scegli la sezione']").click()
-        await page.wait_for_load_state("domcontentloaded", timeout=30000)
+        await _wait_for_ready(page, "select[name='sezione']", label="immobile_sezione_open")
 
         # Controlla se ci sono sezioni disponibili (single evaluate via helper)
         _sez_items_im = await _collect_options_fast(page, "select[name='sezione']")

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import time
+import unicodedata
 from datetime import datetime
 from typing import Optional
 
@@ -218,6 +219,30 @@ async def _login_sielte(page: Page, logger: PageLogger, username: str, password:
         await logger.log(page, "notifica_push")
 
         step = "autorizza"
+        # Fail-fast: il pulsante 'Autorizza' appare solo se username/password
+        # sono corretti e l'autenticazione e' arrivata allo step push. Se le
+        # credenziali sono sbagliate la pagina rimane sulla form di login con
+        # un messaggio d'errore: in tal caso vogliamo fallire entro pochi
+        # secondi invece di aspettare 120s. Soglia configurabile via env
+        # ``LOGIN_AUTORIZZA_APPEAR_TIMEOUT_S`` (default 15).
+        appear_timeout_s = int(os.getenv("LOGIN_AUTORIZZA_APPEAR_TIMEOUT_S", "15"))
+        print(
+            f"[LOGIN] Attendo pulsante 'Autorizza' (max {appear_timeout_s}s) — "
+            f"se non appare = credenziali probabilmente errate"
+        )
+        try:
+            await page.get_by_role("button", name="Autorizza").wait_for(
+                state="visible", timeout=appear_timeout_s * 1000
+            )
+        except PlaywrightTimeoutError as e:
+            current_url = page.url
+            await logger.log(page, f"ERRORE_sielte_{step}_autorizza_non_apparso")
+            raise RuntimeError(
+                f"Login Sielte fallito: pulsante 'Autorizza' non apparso entro "
+                f"{appear_timeout_s}s. Credenziali probabilmente errate o flusso "
+                f"Sielte modificato. URL corrente: {current_url}"
+            ) from e
+
         print("[LOGIN] Clicco 'Autorizza'... (attendo conferma notifica push, timeout 120s)")
         await page.get_by_role("button", name="Autorizza").click(timeout=120000)
         await logger.log(page, "autorizza")
@@ -258,6 +283,33 @@ async def _login_poste(page: Page, logger: PageLogger, username: str, password: 
         await logger.log(page, "avanti")
 
         step = "attesa_app"
+        # Fail-fast: dopo 'Avanti' PosteID transita a uno step di approvazione
+        # push e poi reindirizza al dominio agenziaentrate. Se username/password
+        # sono sbagliate la pagina mostra subito un errore senza mai partire la
+        # push; aspettare 120s prima di accorgersene non e' utile. Diamo prima
+        # ``LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S`` per il cambio di URL/stato e
+        # poi il timeout lungo per l'approvazione vera e propria.
+        appear_timeout_s = int(os.getenv("LOGIN_POSTE_PUSH_APPEAR_TIMEOUT_S", "15"))
+        print(
+            f"[LOGIN] Attendo transizione push PosteID (max {appear_timeout_s}s) — "
+            f"se rimane sulla form = credenziali probabilmente errate"
+        )
+        try:
+            # Attendiamo che l'URL CAMBI dalla pagina di login. wait_for_url
+            # con un pattern wildcard fallisce se restiamo sullo stesso URL.
+            await page.wait_for_function(
+                "url => !window.location.href.includes('login') && !window.location.href.includes('Login')",
+                timeout=appear_timeout_s * 1000,
+            )
+        except PlaywrightTimeoutError as e:
+            current_url = page.url
+            await logger.log(page, f"ERRORE_poste_{step}_push_non_partita")
+            raise RuntimeError(
+                f"Login PosteID fallito: la pagina non e' uscita dal form di login "
+                f"entro {appear_timeout_s}s. Credenziali probabilmente errate o "
+                f"flusso PosteID modificato. URL corrente: {current_url}"
+            ) from e
+
         print("[LOGIN] Attendo approvazione sull'app PosteID (timeout 120s)...")
         # PosteID reindirizza automaticamente dopo l'approvazione sull'app:
         # aspettiamo che il browser torni sul dominio agenziaentrate.
@@ -434,23 +486,37 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
 
         # Gestione sessioni orfane: ogni CloseSessionsSis chiude UNA sessione
         # stale. Dopo molti riavvii possono accumularsi più sessioni, perciò
-        # proviamo fino a 10 volte prima di alzare l'eccezione.
-        for attempt in range(1, 11):
-            content = await page.content()
-            url = page.url
-            if "Utente gia' in sessione" not in content and "error_locked.jsp" not in url:
-                break
+        # proviamo fino a MAX_CLOSE_ATTEMPTS volte prima di alzare l'eccezione.
+        # NB: la struttura `for/else` precedente aveva un off-by-one: dopo
+        # l'N-esimo close+retry il loop terminava senza ricontrollare se la
+        # sessione era stata liberata, quindi sollevava errore anche quando in
+        # realtà l'ultimo tentativo era riuscito. Ora il check è esplicito sia
+        # in testa al loop che dopo l'ultimo close.
+        MAX_CLOSE_ATTEMPTS = 10
 
-            print(f"[LOGIN] Sessione orfana rilevata (tentativo {attempt}/10) — chiudo e riprovo...")
-            step = f"close_session_{attempt}"
+        def _is_orphan(content: str, current_url: str) -> bool:
+            return (
+                "Utente gia' in sessione" in content
+                or "error_locked.jsp" in current_url
+            )
+
+        content = await page.content()
+        url = page.url
+        attempts_done = 0
+        while _is_orphan(content, url) and attempts_done < MAX_CLOSE_ATTEMPTS:
+            attempts_done += 1
+            print(
+                f"[LOGIN] Sessione orfana rilevata (tentativo {attempts_done}/{MAX_CLOSE_ATTEMPTS}) — chiudo e riprovo..."
+            )
+            step = f"close_session_{attempts_done}"
             await page.goto(
                 "https://sister3.agenziaentrate.gov.it/Servizi/CloseSessionsSis",
                 timeout=30000,
             )
             await page.wait_for_load_state("domcontentloaded", timeout=30000)
-            await logger.log(page, f"close_session_{attempt}")
+            await logger.log(page, f"close_session_{attempts_done}")
 
-            step = f"sister_tab_retry_{attempt}"
+            step = f"sister_tab_retry_{attempts_done}"
             await page.goto(
                 "https://iampe.agenziaentrate.gov.it/sam/UI/Login?realm=/agenziaentrate",
                 timeout=30000,
@@ -461,10 +527,16 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
             await page.get_by_role("textbox", name="Password:").fill(password)
             await page.get_by_role("button", name="Accedi").click()
             await page.wait_for_load_state("networkidle", timeout=30000)
-            await logger.log(page, f"portale_sister_retry_{attempt}")
-        else:
+            await logger.log(page, f"portale_sister_retry_{attempts_done}")
+
+            content = await page.content()
+            url = page.url
+
+        if _is_orphan(content, url):
             print("[LOGIN][ERRORE] Troppe sessioni orfane, impossibile liberare la sessione.")
-            raise Exception("Utente già in sessione su un'altra postazione (max 10 tentativi raggiunto)")
+            raise Exception(
+                f"Utente già in sessione su un'altra postazione (max {MAX_CLOSE_ATTEMPTS} tentativi raggiunto)"
+            )
 
         print("[LOGIN] Login SISTER completato.")
 
@@ -473,13 +545,99 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
         raise
 
 
+# Mappa di alias catastali per province con nome ISTAT divergente dal nome
+# usato da SISTER. Chiavi e valori sono già normalizzati con
+# ``_normalize_for_match``. Estendere qui se emergono nuovi casi.
+_CATASTAL_PROVINCE_ALIASES = {
+    "verbano cusio ossola": "verbania",
+    "monza e della brianza": "monza brianza",
+    "forli cesena": "forli",
+    # ISTAT usa "Reggio nell'Emilia", SISTER espone solo "REGGIO EMILIA"
+    # (confermato sperimentalmente, vedi AUDIT_REPORT_2026-05-15.md)
+    "reggio nell emilia": "reggio emilia",
+}
+
+
+def _normalize_for_match(value: str) -> str:
+    """Normalizza una stringa per matching tollerante in ``find_best_option_match``.
+
+    Operazioni applicate (in ordine):
+      1. ``NFKD`` + drop dei combining marks (rimuove accenti à→a, ù→u, ...);
+      2. apostrofi tipografici ``’`` e backtick mappati ad ASCII;
+      3. apostrofi/punteggiatura/separatori (``-``, ``_``, ``/``, ``'``, ...)
+         convertiti in spazio;
+      4. lowercase;
+      5. rimozione del suffisso `` territorio`` (SISTER lo aggiunge alle
+         province, es. ``ALESSANDRIA Territorio``);
+      6. collasso whitespace multipli e strip.
+    """
+    if not value:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", value)
+    no_marks = "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+    no_marks = no_marks.replace("’", "'").replace("`", "'")
+    cleaned = re.sub(r"[-_/'.,]+", " ", no_marks)
+    lowered = cleaned.lower()
+    lowered = re.sub(r"\bterritorio\b", " ", lowered)
+    return re.sub(r"\s+", " ", lowered).strip()
+
+
+async def find_option_by_codice_belfiore(page, selector: str, codice_belfiore: str) -> Optional[str]:
+    """Trova un'option SISTER il cui ``value`` inizia con ``{codice_belfiore}#``.
+
+    Le option di ``select[name='denomComune']`` in SISTER hanno valore nella
+    forma ``CODICEBELFIORE#NOME#0#0`` (es. ``A737#BELFIORE#0#0``,
+    ``H501#ROMA#0#0``). Quando il consumer conosce il codice belfiore catastale
+    (es. da ``parcels.administrativeunit``) può evitare il match stringa sul
+    nome del comune — più robusto perché il codice belfiore è una chiave
+    catastale stabile, mentre i nomi soffrono di varianti ortografiche
+    (apostrofi tipografici, accenti, suffissi).
+
+    Ritorna il ``value`` dell'option oppure ``None`` se nessuna option
+    nel ``select`` ha quel prefisso.
+    """
+    if not codice_belfiore:
+        return None
+    cb = codice_belfiore.strip().upper()
+    if not cb:
+        return None
+    prefix = f"{cb}#"
+    options = await page.locator(f"{selector} option").all()
+    print(f"[MATCH_BELFIORE] Cerco codice belfiore '{cb}' tra {len(options)} option")
+    for option in options:
+        value = await option.get_attribute("value")
+        if value and value.upper().startswith(prefix):
+            text = await option.inner_text()
+            print(f"[MATCH_BELFIORE] Match: '{text}' -> '{value}'")
+            return value
+    print(f"[MATCH_BELFIORE] Nessuna option con prefisso '{prefix}'")
+    return None
+
+
 async def find_best_option_match(page, selector, search_text):
-    """Trova l'opzione che meglio corrisponde al testo cercato"""
+    """Trova l'opzione che meglio corrisponde al testo cercato.
+
+    Il matching è tollerante a:
+      - case (uppercase/lowercase),
+      - accenti (à/è/ì/ò/ù → a/e/i/o/u),
+      - apostrofi tipografici vs ASCII (’ vs '),
+      - separatori (-, _, /) trattati come spazi,
+      - suffissi specifici di SISTER come " Territorio" sulle province,
+      - alias catastali per province con nome divergente da ISTAT
+        (es. "Verbano-Cusio-Ossola" → "Verbania").
+
+    L'ordine di priorità del matching è: exact value → exact text → starts-with
+    → contains → match dell'alias catastale. Restituisce il ``value``
+    dell'option scelta, oppure ``None`` se nessuna opzione è plausibile.
+    """
     options = await page.locator(f"{selector} option").all()
     best_match = None
     best_score = 0
 
     print(f"[MATCH] Cerco '{search_text}' tra {len(options)} opzioni")
+
+    search_norm = _normalize_for_match(search_text)
+    search_alias = _CATASTAL_PROVINCE_ALIASES.get(search_norm)
 
     for option in options:
         value = await option.get_attribute("value")
@@ -492,40 +650,60 @@ async def find_best_option_match(page, selector, search_text):
         search_upper = search_text.upper()
         text_upper = text.upper()
         value_upper = value.upper()
+        text_norm = _normalize_for_match(text)
+        value_norm = _normalize_for_match(value)
 
         # PRIORITÀ 1: Exact match del valore (per sezioni come P, Q, etc.)
-        if search_upper == value_upper:
+        if search_upper == value_upper or search_norm == value_norm:
             print(f"[MATCH] Exact value match trovato: '{text}' -> '{value}'")
             return value
 
-        # PRIORITÀ 2: Exact match del testo
-        if search_upper == text_upper:
+        # PRIORITÀ 2: Exact match del testo (incluso match normalizzato senza
+        # accenti/apostrofi/suffisso " Territorio")
+        if search_upper == text_upper or search_norm == text_norm:
             print(f"[MATCH] Exact text match trovato: '{text}' -> '{value}'")
             return value
 
         # PRIORITÀ 3: Match che inizia con il testo cercato
-        if text_upper.startswith(search_upper):
-            score = len(search_text) / len(text)
+        if text_upper.startswith(search_upper) or text_norm.startswith(search_norm):
+            score = len(search_norm) / max(len(text_norm), 1)
             if score > best_score:
                 best_score = score
                 best_match = value
                 print(f"[MATCH] Candidato (starts with): '{text}' -> '{value}' (score: {score:.2f})")
+            continue
 
         # PRIORITÀ 4: Value che inizia con il testo cercato
-        elif value_upper.startswith(search_upper):
-            score = len(search_text) / len(value) * 0.9  # Leggera penalità
+        if value_upper.startswith(search_upper) or value_norm.startswith(search_norm):
+            score = len(search_norm) / max(len(value_norm), 1) * 0.9
             if score > best_score:
                 best_score = score
                 best_match = value
                 print(f"[MATCH] Candidato (value starts with): '{text}' -> '{value}' (score: {score:.2f})")
+            continue
 
         # PRIORITÀ 5: Match che contiene il testo cercato
-        elif search_upper in text_upper:
-            score = len(search_text) / len(text) * 0.6  # Maggiore penalità per evitare falsi positivi
+        if search_upper in text_upper or (search_norm and search_norm in text_norm):
+            score = len(search_norm) / max(len(text_norm), 1) * 0.6
             if score > best_score:
                 best_score = score
                 best_match = value
                 print(f"[MATCH] Candidato (contains): '{text}' -> '{value}' (score: {score:.2f})")
+            continue
+
+        # PRIORITÀ 6: Alias catastale (es. Verbano-Cusio-Ossola → Verbania)
+        if search_alias and (
+            text_norm == search_alias
+            or text_norm.startswith(search_alias)
+            or search_alias in text_norm
+        ):
+            score = len(search_alias) / max(len(text_norm), 1) * 0.5
+            if score > best_score:
+                best_score = score
+                best_match = value
+                print(
+                    f"[MATCH] Candidato (alias '{search_alias}'): '{text}' -> '{value}' (score: {score:.2f})"
+                )
 
     if best_match:
         print(f"[MATCH] Migliore match trovato: '{best_match}' (score: {best_score:.2f})")
@@ -545,6 +723,7 @@ async def run_visura(
     tipo_catasto="T",
     extract_intestati=True,
     subalterno=None,
+    codice_belfiore: Optional[str] = None,
 ):
     time0 = time.time()
     logger = PageLogger("visura")
@@ -657,7 +836,23 @@ async def run_visura(
         f"[VISURA] Comuni disponibili: {', '.join(available_comuni[:10])}{'...' if len(available_comuni) > 10 else ''}"
     )
 
-    comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
+    # Quando il chiamante fornisce il codice belfiore (es. da `parcels.administrativeunit`)
+    # bypassiamo il match-by-name e selezioniamo l'option per prefisso di `value`
+    # (`CODICEBELFIORE#…`), che è più robusto per i comuni con nomi ambigui o
+    # varianti ortografiche divergenti tra ISTAT e SISTER.
+    comune_value = None
+    if codice_belfiore:
+        comune_value = await find_option_by_codice_belfiore(
+            page, "select[name='denomComune']", codice_belfiore
+        )
+        if not comune_value:
+            print(
+                f"[VISURA] codice_belfiore='{codice_belfiore}' non trovato nelle option, "
+                f"fallback al match per nome '{comune}'"
+            )
+
+    if not comune_value:
+        comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
 
     if not comune_value:
         raise Exception(
@@ -1191,7 +1386,8 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
 
 async def run_visura_immobile(
-    page, provincia="Trieste", comune="Trieste", sezione=None, foglio="9", particella="166", subalterno=None
+    page, provincia="Trieste", comune="Trieste", sezione=None, foglio="9", particella="166", subalterno=None,
+    codice_belfiore: Optional[str] = None,
 ):
     """
     Esegue una visura catastale per un immobile specifico (solo per fabbricati con subalterno).
@@ -1257,7 +1453,18 @@ async def run_visura_immobile(
 
     # Trova e seleziona il comune
     print(f"[VISURA_IMMOBILE] Cercando comune: {comune}")
-    comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
+    comune_value = None
+    if codice_belfiore:
+        comune_value = await find_option_by_codice_belfiore(
+            page, "select[name='denomComune']", codice_belfiore
+        )
+        if not comune_value:
+            print(
+                f"[VISURA_IMMOBILE] codice_belfiore='{codice_belfiore}' non trovato, "
+                f"fallback al match per nome '{comune}'"
+            )
+    if not comune_value:
+        comune_value = await find_best_option_match(page, "select[name='denomComune']", comune)
 
     if not comune_value:
         raise Exception(f"Comune '{comune}' non trovato nelle opzioni disponibili")

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 zornade (https://zornade.com)
 # See LICENSE, NOTICE, and COMMERCIAL-LICENSE.md at the repository root.
 
+import asyncio
 import logging
 import os
 import re
@@ -80,7 +81,9 @@ def parse_table(html):
             # Se ci sono meno celle che header, aggiungi celle vuote
             while len(cells) < len(headers):
                 cells.append("")
-            rows.append(dict(zip(headers, cells)))
+            # strict=False: cells is pre-padded to len(headers); extra cells
+            # (rare: malformed HTML with more <td> than <th>) are intentionally dropped.
+            rows.append(dict(zip(headers, cells, strict=False)))
     return rows
 
 
@@ -158,11 +161,22 @@ class PageLogger:
             safe_name = re.sub(r"[^\w\-]", "_", step_name)
             filename = f"{self.step:02d}_{safe_name}.html"
             filepath = os.path.join(self.base_dir, filename)
-            with open(filepath, "w", encoding="utf-8") as f:
-                f.write(f"<!-- URL: {url} -->\n")
-                f.write(f"<!-- Step: {step_name} -->\n")
-                f.write(f"<!-- Timestamp: {datetime.now().isoformat()} -->\n\n")
-                f.write(html)
+            # Write off the event loop: open()/write() are blocking syscalls
+            # and were previously freezing the asyncio loop for the duration
+            # of the disk write (ASYNC230). We use asyncio.to_thread so any
+            # I/O slowness (e.g. EBS, full disk) cannot starve the loop.
+            payload = (
+                f"<!-- URL: {url} -->\n"
+                f"<!-- Step: {step_name} -->\n"
+                f"<!-- Timestamp: {datetime.now().isoformat()} -->\n\n"
+                f"{html}"
+            )
+
+            def _write_file() -> None:
+                with open(filepath, "w", encoding="utf-8") as f:
+                    f.write(payload)
+
+            await asyncio.to_thread(_write_file)
             print(f"[PAGE_LOG] {self.flow_name}/{filename}")
         except Exception as e:
             print(f"[PAGE_LOG] Errore salvataggio {step_name}: {e}")

--- a/utils.py
+++ b/utils.py
@@ -669,23 +669,29 @@ def _normalize_for_match(value: str) -> str:
 _DROPDOWN_CACHE: dict = {}
 
 
-async def _wait_for_ready(page, selector: str, timeout_ms: int = 30000, label: str = "") -> None:
-    """Attende che ``selector`` sia attached/visible nel DOM.
+async def _wait_for_ready(page, selector: str, timeout_ms: int = 15000, label: str = "") -> None:
+    """Attende che ``selector`` sia presente (``attached``) nel DOM.
 
     Sostituisce il pattern ``wait_for_load_state("domcontentloaded")`` quando
-    il vero "ready" del passo \u00e8 la presenza di un elemento target specifico
-    (es. la prossima ``<select>`` del form, il link "Immobile", la tabella
-    risultati). Ritorna appena il selector \u00e8 visibile (tipicamente molto
-    prima del DOMContentLoaded completo, perch\u00e9 SISTER carica asset extra
-    dopo che il form \u00e8 gi\u00e0 interattivo).
+    il vero "ready" del passo è la presenza di un elemento target specifico
+    (es. la prossima ``<select>`` del form, il link "Immobile"). Ritorna
+    appena il selector è ATTACHED nel DOM (non richiede visibility) — questo
+    è sufficiente per gli step successivi (``select_option``, ``click``,
+    ``page.evaluate`` per estrarre option) che fanno auto-wait di visibility
+    se serve, e copre i casi in cui SISTER nasconde temporaneamente l'elemento
+    durante transitions server-side. Lo stato ``visible`` è troppo stretto e
+    causa timeout su intermittenze di rendering (regressione live osservata
+    2026-05-15: 6 timeout su 97 req).
 
-    Diagnostica: stampa ``[WAIT] label='...' selector='...' elapsed=Yms`` per
-    grep delle latenze. In caso di timeout l'eccezione Playwright fa propagare
-    il contesto al chiamante.
+    Timeout default 15s (vs 30s di ``wait_for_load_state``) per fail-fast su
+    pagine che non caricano. Diagnostica: stampa
+    ``[WAIT] label='...' selector='...' elapsed=Yms`` per grep delle latenze.
+    In caso di timeout l'eccezione Playwright fa propagare il contesto al
+    chiamante.
     """
     t0 = time.time()
     try:
-        await page.wait_for_selector(selector, state="visible", timeout=timeout_ms)
+        await page.wait_for_selector(selector, state="attached", timeout=timeout_ms)
     finally:
         elapsed_ms = (time.time() - t0) * 1000
         print(f"[WAIT] label='{label}' selector='{selector}' elapsed={elapsed_ms:.0f}ms")

--- a/utils.py
+++ b/utils.py
@@ -271,13 +271,23 @@ async def _login_poste(page: Page, logger: PageLogger, username: str, password: 
 async def login(page: Page):
     """Esegue il login completo (SPID + navigazione fino a 'Visure catastali').
 
-    Il provider SPID è selezionato dalla variabile d'ambiente ``SPID_PROVIDER``:
+    Il provider di autenticazione è selezionato dalla variabile d'ambiente
+    ``SPID_PROVIDER`` (case-insensitive):
 
-    * ``sielte`` (default) — Sielte ID, credenziali ``ADE_USERNAME`` / ``ADE_PASSWORD``
-    * ``poste`` — PosteID, credenziali ``POSTE_USERNAME`` / ``POSTE_PASSWORD``
+    * ``sielte`` (default) — SPID Sielte ID, credenziali ``ADE_USERNAME`` /
+      ``ADE_PASSWORD``.
+    * ``poste`` — SPID PosteID, credenziali ``POSTE_USERNAME`` /
+      ``POSTE_PASSWORD``.
+    * ``sister`` — login diretto SISTER tramite il tab dedicato della pagina
+      ADE, credenziali ``SISTER_USERNAME`` / ``SISTER_PASSWORD``. Pensato per
+      l'**intestatario** di una convenzione SISTER che vuole automatizzare le
+      proprie consultazioni con le proprie credenziali nominali (vedi README,
+      sezione "Provider di autenticazione supportati").
 
-    Dopo l'autenticazione SPID il flusso prosegue identico: ricerca del servizio
+    Con i provider SPID il flusso prosegue identico: ricerca del servizio
     SISTER, conferma, navigazione fino a "Visure catastali → Conferma Lettura".
+    Con il provider ``sister`` il login diretto atterra già nell'area del
+    servizio e quei passi vengono saltati.
     """
     spid_provider = os.getenv("SPID_PROVIDER", "sielte").lower()
 
@@ -291,8 +301,16 @@ async def login(page: Page):
         password = os.getenv("POSTE_PASSWORD")
         if not username or not password:
             raise ValueError("POSTE_USERNAME and POSTE_PASSWORD environment variables must be set")
+    elif spid_provider == "sister":
+        username = os.getenv("SISTER_USERNAME")
+        password = os.getenv("SISTER_PASSWORD")
+        if not username or not password:
+            raise ValueError("SISTER_USERNAME and SISTER_PASSWORD environment variables must be set")
     else:
-        raise ValueError(f"SPID_PROVIDER non supportato: '{spid_provider}'. Valori validi: 'sielte', 'poste'")
+        raise ValueError(
+            f"SPID_PROVIDER non supportato: '{spid_provider}'. "
+            "Valori validi: 'sielte', 'poste', 'sister'"
+        )
 
     logger = PageLogger("login")
     step = "init"
@@ -302,6 +320,15 @@ async def login(page: Page):
         print("[LOGIN] Navigo alla pagina di login...")
         await page.goto("https://iampe.agenziaentrate.gov.it/sam/UI/Login?realm=/agenziaentrate")
         await logger.log(page, "goto_login")
+
+        if spid_provider == "sister":
+            # Login diretto SISTER: bypass completo della navigazione ADE portal
+            # (cerca SISTER → Vai al servizio → Conferma → Consultazioni →
+            # Visure catastali → Conferma Lettura) perché l'area servizio si
+            # apre già dopo l'autenticazione SISTER nominale.
+            step = "provider_sister"
+            await _login_sister_direct(page, logger, username, password)
+            return
 
         step = "entra_con_spid"
         print("[LOGIN] Clicco 'Entra con SPID'...")
@@ -359,6 +386,62 @@ async def login(page: Page):
 
     except Exception:
         await logger.log(page, f"ERRORE_{step}")
+        raise
+
+
+async def _login_sister_direct(page: Page, logger: PageLogger, username: str, password: str) -> None:
+    """Esegue il login diretto SISTER tramite il tab dedicato sulla pagina ADE.
+
+    Credenziali richieste:
+        SISTER_USERNAME — username dell'account SISTER nominale dell'utente
+        SISTER_PASSWORD — password dell'account SISTER nominale dell'utente
+
+    Scope d'uso ammesso: questo flusso è destinato all'**intestatario della
+    convenzione SISTER** che desidera automatizzare le proprie consultazioni
+    con le proprie credenziali nominali. Non è destinato a chi vuole rivendere
+    o esporre l'accesso al portale SISTER a terzi (la convenzione SISTER
+    richiede che l'utenza sia personale, non cedibile, e che le consultazioni
+    siano riconducibili all'intestatario).
+
+    Dopo il login si atterra direttamente nella pagina SceltaServizio di
+    SISTER, saltando la navigazione tramite portale ADE (Cerca servizio →
+    Vai al servizio → Conferma → Consultazioni → Visure catastali → Conferma
+    Lettura) che non è necessaria con il login diretto.
+    """
+    step = "sister_tab"
+    try:
+        print("[LOGIN] Clicco tab 'Sister'...")
+        await page.get_by_role("tab", name="Sister").click()
+        await logger.log(page, "sister_tab")
+
+        step = "username"
+        print("[LOGIN] Inserisco username SISTER...")
+        await page.get_by_role("textbox", name="Utente:").fill(username)
+        await logger.log(page, "username")
+
+        step = "password"
+        print("[LOGIN] Inserisco password SISTER...")
+        await page.get_by_role("textbox", name="Password:").fill(password)
+
+        step = "accedi"
+        print("[LOGIN] Clicco 'Accedi'...")
+        await page.get_by_role("button", name="Accedi").click()
+        await logger.log(page, "accedi")
+
+        step = "attesa_sister"
+        print("[LOGIN] Attendo caricamento portale SISTER...")
+        await page.wait_for_load_state("networkidle", timeout=30000)
+        await logger.log(page, "portale_sister")
+
+        # Verifica blocco sessione (stessa logica del flusso SPID)
+        content = await page.content()
+        url = page.url
+        if "Utente gia' in sessione" in content or "error_locked.jsp" in url:
+            print("[LOGIN][ERRORE] Utente già in sessione su un'altra postazione!")
+            raise Exception("Utente già in sessione su un'altra postazione")
+
+    except Exception:
+        await logger.log(page, f"ERRORE_sister_{step}")
         raise
 
 

--- a/utils.py
+++ b/utils.py
@@ -555,6 +555,12 @@ _CATASTAL_PROVINCE_ALIASES = {
     # ISTAT usa "Reggio nell'Emilia", SISTER espone solo "REGGIO EMILIA"
     # (confermato sperimentalmente, vedi AUDIT_REPORT_2026-05-15.md)
     "reggio nell emilia": "reggio emilia",
+    # Sud Sardegna è stata istituita nel 2016 ma SISTER (catasto) la mappa
+    # ancora sotto CAGLIARI Territorio (es. Carloforte, Buggerru, Iglesias,
+    # Senorbì). Scoperto nel bulk-test 89 particelle del 2026-05-15.
+    "sud sardegna": "cagliari",
+    # ISTAT usa "Pesaro e Urbino", SISTER espone solo "PESARO Territorio".
+    "pesaro e urbino": "pesaro",
 }
 
 

--- a/utils.py
+++ b/utils.py
@@ -516,10 +516,7 @@ async def _login_sister_direct(page: Page, logger: PageLogger, username: str, pa
         MAX_CLOSE_ATTEMPTS = 10
 
         def _is_orphan(content: str, current_url: str) -> bool:
-            return (
-                "Utente gia' in sessione" in content
-                or "error_locked.jsp" in current_url
-            )
+            return "Utente gia' in sessione" in content or "error_locked.jsp" in current_url
 
         content = await page.content()
         url = page.url
@@ -606,13 +603,13 @@ _CATASTAL_PROVINCE_ALIASES = {
 _UNSUPPORTED_PROVINCES_SISTER = {
     # Provincia Autonoma di Trento — Catasto Tavolare (Libro Fondiario)
     "trento": "Provincia Autonoma di Trento: catasto gestito dal Sistema "
-              "Tavolare (Libro Fondiario), non disponibile su SISTER.",
+    "Tavolare (Libro Fondiario), non disponibile su SISTER.",
     # Provincia Autonoma di Bolzano / Südtirol — Catasto Tavolare
     "bolzano": "Provincia Autonoma di Bolzano: catasto gestito dal Sistema "
-               "Tavolare (Libro Fondiario), non disponibile su SISTER.",
+    "Tavolare (Libro Fondiario), non disponibile su SISTER.",
     "bolzano bozen": "Provincia Autonoma di Bolzano: catasto gestito dal "
-                     "Sistema Tavolare (Libro Fondiario), non disponibile "
-                     "su SISTER.",
+    "Sistema Tavolare (Libro Fondiario), non disponibile "
+    "su SISTER.",
 }
 
 
@@ -815,10 +812,7 @@ async def _get_comune_options(page, provincia_value: Optional[str]) -> dict:
         key = ("comune", provincia_value)
         cached = _DROPDOWN_CACHE.get(key)
         if cached is not None:
-            print(
-                f"[CACHE] hit kind=comune provincia='{provincia_value}' "
-                f"count={len(cached['items'])}"
-            )
+            print(f"[CACHE] hit kind=comune provincia='{provincia_value}' " f"count={len(cached['items'])}")
             return cached
         print(f"[CACHE] miss kind=comune provincia='{provincia_value}' fetching live")
     elif not provincia_value:
@@ -874,10 +868,7 @@ async def find_option_by_codice_belfiore(
             print(f"[MATCH_BELFIORE] hit cache cb='{cb}' -> '{value}'")
             return value
         # No-hit: log e ritorna None (caller fa fallback su match by name)
-        print(
-            f"[MATCH_BELFIORE] miss cb='{cb}' tra {len(idx['items'])} option "
-            f"(comuni provincia corrente)"
-        )
+        print(f"[MATCH_BELFIORE] miss cb='{cb}' tra {len(idx['items'])} option " f"(comuni provincia corrente)")
         return None
     # Path generico (no cache): un solo evaluate + scan
     items = await _collect_options_fast(page, selector)
@@ -991,17 +982,13 @@ async def find_best_option_match(page, selector, search_text, provincia_value: O
 
         # PRIORITÀ 6: Alias catastale (es. Verbano-Cusio-Ossola → Verbania)
         if search_alias and (
-            text_norm == search_alias
-            or text_norm.startswith(search_alias)
-            or search_alias in text_norm
+            text_norm == search_alias or text_norm.startswith(search_alias) or search_alias in text_norm
         ):
             score = len(search_alias) / max(len(text_norm), 1) * 0.5
             if score > best_score:
                 best_score = score
                 best_match = value
-                print(
-                    f"[MATCH] Candidato (alias '{search_alias}'): '{text}' -> '{value}' (score: {score:.2f})"
-                )
+                print(f"[MATCH] Candidato (alias '{search_alias}'): '{text}' -> '{value}' (score: {score:.2f})")
 
     if best_match:
         print(f"[MATCH] Migliore match trovato: '{best_match}' (score: {best_score:.2f})")
@@ -1142,7 +1129,9 @@ async def run_visura(
     comune_value = None
     if codice_belfiore:
         comune_value = await find_option_by_codice_belfiore(
-            page, "select[name='denomComune']", codice_belfiore,
+            page,
+            "select[name='denomComune']",
+            codice_belfiore,
             provincia_value=provincia_value,
         )
         if not comune_value:
@@ -1153,7 +1142,9 @@ async def run_visura(
 
     if not comune_value:
         comune_value = await find_best_option_match(
-            page, "select[name='denomComune']", comune,
+            page,
+            "select[name='denomComune']",
+            comune,
             provincia_value=provincia_value,
         )
 
@@ -1678,7 +1669,13 @@ async def extract_all_sezioni(page: Page, tipo_catasto: str = "T", max_province:
 
 
 async def run_visura_immobile(
-    page, provincia="Trieste", comune="Trieste", sezione=None, foglio="9", particella="166", subalterno=None,
+    page,
+    provincia="Trieste",
+    comune="Trieste",
+    sezione=None,
+    foglio="9",
+    particella="166",
+    subalterno=None,
     codice_belfiore: Optional[str] = None,
 ):
     """
@@ -1758,7 +1755,9 @@ async def run_visura_immobile(
     comune_value = None
     if codice_belfiore:
         comune_value = await find_option_by_codice_belfiore(
-            page, "select[name='denomComune']", codice_belfiore,
+            page,
+            "select[name='denomComune']",
+            codice_belfiore,
             provincia_value=provincia_value,
         )
         if not comune_value:
@@ -1768,7 +1767,9 @@ async def run_visura_immobile(
             )
     if not comune_value:
         comune_value = await find_best_option_match(
-            page, "select[name='denomComune']", comune,
+            page,
+            "select[name='denomComune']",
+            comune,
             provincia_value=provincia_value,
         )
 


### PR DESCRIPTION
## Issue collegata

Risolve #38

## Descrizione

PR di consolidamento del lavoro post-#36 sul branch `feat/sister-direct-login`: robustezza login/sessione SISTER, normalizzazione nomi province/comuni, performance MVP+MVP-2, retry automatico del login su timeout della push SPID.

Risultato live (97 particelle bulk test, particelle in tutta Italia):
- **6.7s avg / 91.8% success / 0 timeout `wait_for_selector`**
- Da baseline pre-MVP ~10.3s a 6.7s (-35%)

## Cosa cambia (sintesi)

### Robustezza login SPID
- `BrowserManager.login()` ora ritenta automaticamente fino a `LOGIN_MAX_ATTEMPTS` volte (default 3) quando la push SPID non viene approvata in tempo (`PlaywrightTimeoutError`). Pausa configurabile via `LOGIN_RETRY_DELAY_S` (default 5s).
- Fail-fast preservato per credenziali errate (15s) — non si ribombarda di push se username/password sono sbagliati.
- Single-flight lock su login concorrente; fix TOCTOU su browser readiness.

### Normalizzazione input
- Alias province (`Reggio nell'Emilia` → `Reggio Emilia`, `Valle d'Aosta/Vallée d'Aoste`, `Monza e della Brianza`, …).
- Match comune case-insensitive + accent-fold.
- `codice_belfiore` opzionale → match nativo SISTER tramite chiave `CB#…` (più affidabile del match per nome).
- Fail-fast esplicito su Trento/Bolzano (catasto autonomo).

### Performance
- Resource blocking (immagini/font/analytics).
- Dropdown cache TTL + `fast_options` JS path.
- Cache comuni **provincia-scoped** (fix poisoning cross-provincia).
- Hot path `wait_for_selector(state="attached", timeout=15s)` invece di `wait_for_load_state(domcontentloaded, 30s)`.

### Resilienza
- `TTLCache` su risultati visura.
- Fallback T↔F catasto opzionale.
- Rate-limit (HTTP 429) su richieste concorrenti.

## Tipo di modifica

- [x] Bug fix (corregge un problema senza rompere funzionalità esistenti)
- [x] Nuova feature (aggiunge funzionalità senza rompere quelle esistenti)
- [ ] Breaking change
- [ ] Documentazione
- [ ] Refactoring (nessun cambio funzionale)

## Checklist

- [x] Ho letto CONTRIBUTING.md
- [x] La mia PR è basata sull'ultimo `main` (ho fatto rebase/merge dopo #36)
- [x] Ho testato le modifiche localmente (104/104 pytest + bulk test live 97 particelle)
- [x] Il codice passa `ruff check .` e `black --check .`
- [ ] Ho aggiornato il CHANGELOG.md (verrà fatto al rilascio versione)
- [x] Ho aggiunto/aggiornato i test (+50 nuovi test pytest)
- [x] Non ho committato credenziali, dati personali o file `.env`

## Uso di strumenti AI

- [x] Ho usato strumenti AI come supporto: GitHub Copilot (Claude) per assistenza alla scrittura del codice, dei test e dei messaggi di commit. Tutto il codice è stato revisionato e validato localmente con test unitari e bulk test live contro l'ambiente reale SISTER.

## Log / Numeri

Bulk test v7 (97 particelle, varietà geografica nord/centro/sud):
```
Total          97
HTTP 200       96/97  (99%)
Success        89/97  (91.8%)
Avg latency    6.7s
P50 latency    5.9s
P95 latency    11.2s
wait_for_selector timeouts  0
```

Pytest:
```
104 passed in 0.38s
```

## Note per il reviewer

Il branch contiene 14 commit logicamente distinti (P0 audit, perf MVP, perf MVP-2, cache fix, hot path D, retry login). Suggerito **squash merge** in modo da avere un singolo commit consolidato su `main` che riassume "robustezza + performance + retry login pre-produzione".
