### PR TITLE
[codex] docs: aggiunge note su protezione dati e retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Servizio REST per l'estrazione automatizzata di dati catastali dal portale **SIS
   - [Shutdown](#shutdown)
 - [Esempi d'uso](#esempi-duso)
 - [Logging e debug](#logging-e-debug)
+- [Protezione dati e retention](#protezione-dati-e-retention)
 - [Dettagli tecnici](#dettagli-tecnici)
 - [Sviluppo e contribuzione](#sviluppo-e-contribuzione)
 - [Risoluzione dei problemi](#risoluzione-dei-problemi)
@@ -582,6 +583,22 @@ Ogni file HTML include in testa dei commenti con metadati:
 ```
 
 > **Privacy:** la directory `logs/pages/` è nel `.gitignore` perché i file HTML contengono dati personali (codice fiscale, intestatari, indirizzi). Non committare mai questi file.
+
+---
+
+## Protezione dati e retention
+
+I dati estratti da SISTER e i log HTML generati da `PageLogger` possono contenere dati personali e informazioni patrimoniali. Chi esegue il servizio è responsabile della configurazione, conservazione, protezione e cancellazione di questi dati nel proprio ambiente.
+
+Raccomandazioni operative:
+
+- Imposta `LOG_PAGES=0` in produzione, salvo sessioni di debug mirate.
+- Conserva `logs/visura.log` e `logs/pages/` solo per il tempo necessario a diagnosi, audit tecnico o obblighi interni documentati.
+- Cancella o anonimizza i file HTML prima di condividerli in issue, PR, chat o ticket di supporto.
+- Proteggi l'accesso a `logs/`, backup e volumi Docker con gli stessi controlli usati per dati personali.
+- Definisci una procedura di retention esplicita per risultati in memoria, file di log e copie di backup.
+
+Il progetto non applica ancora un mascheramento automatico dei dati nei log HTML: verifica sempre manualmente i file prima di esportarli fuori dal tuo ambiente.
 
 ---
 


### PR DESCRIPTION
## Issue collegata

Collega #15

## Descrizione

Aggiunge al README una breve sezione su protezione dati e retention per risultati e log HTML generati dal servizio.

## Tipo di modifica

- [ ] Bug fix (corregge un problema senza rompere funzionalità esistenti)
- [ ] Nuova feature (aggiunge funzionalità senza rompere funzionalità esistenti)
- [ ] Breaking change (modifica che potrebbe rompere funzionalità esistenti)
- [x] Documentazione
- [ ] Refactoring (nessun cambio funzionale)

## Checklist

- [x] Ho letto [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] La mia PR è basata sull'ultimo `main`
- [x] Ho testato le modifiche localmente
- [ ] Il codice passa `ruff check .` e `black --check .`
- [x] Ho aggiornato il CHANGELOG.md (se applicabile)
- [x] Ho aggiunto/aggiornato i test (se applicabile)
- [x] Non ho committato credenziali, dati personali o file `.env`

## Uso di strumenti AI

- [ ] Non ho usato strumenti AI per questa PR
- [x] Ho usato strumenti AI come supporto: ChatGPT/Codex per individuare una modifica minima, preparare il testo e verificare il diff.

## Screenshot / Log

Non applicabile. Verifiche locali:

- `git diff --check`
- `python3 -m pytest -q` non eseguito fino in fondo: dipendenze locali mancanti (`fastapi`, `playwright`).

## Note per il reviewer

PR volutamente minimale: solo documentazione, nessun cambio runtime.